### PR TITLE
Simplify code block prompts & Add doc tests in some tutorials

### DIFF
--- a/docs/tutorials/plots.rst
+++ b/docs/tutorials/plots.rst
@@ -2,8 +2,6 @@
 
 .. _plots:
 
-.. doctest-skip-all
-
 ***********************
 Plotting with Astroplan
 ***********************
@@ -53,15 +51,23 @@ These take, at minimum, `astroplan.Observer`, `astroplan.FixedTarget` and
 
 .. _plots_airmass:
 
-Airmass versus time plots are made in the following manner::
+Airmass vs time plots are made the following way:
 
-    plot_airmass(target, observer, time)
+.. code-block:: python
+
+    >>> from astroplan.plots import plot_airmass
+
+    >>> plot_airmass(target, observer, time)
 
 .. _plots_parallactic:
 
-Parallactic angle vs time plots are made in the following manner::
+Parallactic angle vs time plots are made the following way:
 
-    plot_parallactic(target, observer, time)
+.. code-block:: python
+
+    >>> from astroplan.plots import plot_airmass
+
+    >>> plot_parallactic(target, observer, time)
 
 Below are general guidelines for working with time-dependent plots in
 `astroplan`.  Examples use airmass but apply to parallactic angle as well.
@@ -80,14 +86,18 @@ a quick plot over a 24-hour period.
 
 After constructing `astroplan.Observer` and `astroplan.FixedTarget` objects,
 construct a `astropy.time.Time` object with a single instance in time and issue
-the plotting command::
+the plotting command.
 
-    from astropy.time import Time
+.. code-block:: python
 
-    observe_time = Time('2015-06-15 23:30:00')
+    >>> import matplotlib.pyplot as plt
+    >>> from astropy.time import Time
+    >>> from astroplan.plots import plot_airmass
 
-    plot_airmass(target, observer, observe_time)
-    plt.show()
+    >>> observe_time = Time('2015-06-15 23:30:00')
+
+    >>> plot_airmass(target, observer, observe_time)
+    >>> plt.show()
 
 .. plot::
 
@@ -148,16 +158,21 @@ use `Numpy`_ and `astropy.units`.  See example below.
 Centering the window at some time
 +++++++++++++++++++++++++++++++++
 
-To center your window at some instance in time::
+To center your window at some instance in time:
 
-    import numpy as np
-    import astropy.units as u
+ .. code-block:: python
 
-    observe_time = Time('2015-06-15 23:30:00')
-    observe_time = observe_time + np.linspace(-5, 5, 55)*u.hour
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> import astropy.units as u
+    >>> from astropy.time import Time
+    >>> from astroplan.plots import plot_airmass
 
-    plot_airmass(target, observer, observe_time)
-    plt.show()
+    >>> observe_time = Time('2015-06-15 23:30:00')
+    >>> observe_time = observe_time + np.linspace(-5, 5, 55)*u.hour
+
+    >>> plot_airmass(target, observer, observe_time)
+    >>> plt.show()
 
 .. plot::
 
@@ -202,13 +217,18 @@ Specify start and end times
 If you know the start and end times of your observation run, you can use a
 `astropy.time.TimeDelta` object to create an array for time input::
 
-    start_time = Time('2015-06-15 20:00:00')
-    end_time = Time('2015-06-16 04:00:00')
-    delta_t = end_time - start_time
-    observe_time = start_time + delta_t*np.linspace(0, 1, 75)
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> from astropy.time import Time
+    >>> from astroplan.plots import plot_airmass
 
-    plot_airmass(target, observer, observe_time)
-    plt.show()
+    >>> start_time = Time('2015-06-15 20:00:00')
+    >>> end_time = Time('2015-06-16 04:00:00')
+    >>> delta_t = end_time - start_time
+    >>> observe_time = start_time + delta_t*np.linspace(0, 1, 75)
+
+    >>> plot_airmass(target, observer, observe_time)
+    >>> plt.show()
 
 .. plot::
 
@@ -254,20 +274,19 @@ If you want to plot airmass information for multiple targets, simply reissue
 the `plot_airmass` command, using a different `FixedTarget` object as input this
 time. Repeat until you have as many targets on the plot as you wish::
 
-    coordinates = SkyCoord('02h31m49.09s', '+89d15m50.8s', frame='icrs')
-    other_target = FixedTarget(name='Polaris', coord=coordinates)
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> from astropy.time import Time
+    >>> from astroplan.plots import plot_airmass
 
-    coordinates = SkyCoord('07h45m19.4s', '+28d01m35s', frame='icrs')
-    third_target = FixedTarget(name='Pollux', coord=coordinates)
+    >>> observe_time = Time('2015-06-30 23:30:00') + np.linspace(-7.0, 5.5, 50)*u.hour
 
-    observe_time = Time('2015-06-30 23:30:00') + np.linspace(-7.0, 5.5, 50)*u.hour
+    >>> plot_airmass(target, observer, observe_time)
+    >>> plot_airmass(other_target, observer, observe_time)
+    >>> plot_airmass(third_target, observer, observe_time)
 
-    plot_airmass(target, observer, observe_time)
-    plot_airmass(other_target, observer, observe_time)
-    plot_airmass(third_target, observer, observe_time)
-
-    plt.legend(shadow=True, loc=2)
-    plt.show()
+    >>> plt.legend(shadow=True, loc=2)
+    >>> plt.show()
 
 .. plot::
 
@@ -323,16 +342,21 @@ Changing style options
 The default line for time-dependent plots is solid and the default label (should
 you choose to display a legend) is the name contained in the `Target` object.
 You can change the *linestyle*, *color*, *label* and other plotting properties
-by setting the *style_kwargs* option::
+by setting the *style_kwargs* option.
 
-    sirius_styles = {'linestyle': '--', 'color': 'r'}
-    pollux_styles = {'color': 'g'}
+.. code-block:: python
 
-    plot_airmass(target, observer, observe_time, style_kwargs=sirius_styles)
-    plot_airmass(other_target, observer, observe_time, style_kwargs=pollux_styles)
+    >>> import matplotlib.pyplot as plt
+    >>> from astroplan.plots import plot_airmass
 
-    plt.legend(shadow=True, loc=2)
-    plt.show()
+    >>> sirius_styles = {'linestyle': '--', 'color': 'r'}
+    >>> pollux_styles = {'color': 'g'}
+
+    >>> plot_airmass(target, observer, observe_time, style_kwargs=sirius_styles)
+    >>> plot_airmass(other_target, observer, observe_time, style_kwargs=pollux_styles)
+
+    >>> plt.legend(shadow=True, loc=2)
+    >>> plt.show()
 
 .. plot::
 
@@ -392,13 +416,17 @@ with respect to their local horizon, as well as the positions of familiar stars
 or other objects to act as guides.
 
 `plot_sky` allows you to plot the positions of targets at a single instance or
-over some window of time with a command such as::
+over some window of time.  You make this plot the following way:
 
-    plot_sky(target, observer, time)
+.. code-block:: python
+
+    >>> from astroplan.plots import plot_sky
+
+    >>> plot_sky(target, observer, time)
 
 .. warning::
 
-    Note that the time input for `plot_sky` has to either be an array of
+    Note that the *time* input for `plot_sky` has to either be an array of
     `astropy.time.Time` objects or has to be an `astropy.time.Time` object
     containing an array of times--in other words, it **cannot** be scalar.  See
     `astropy`'s documentation for more details.
@@ -423,27 +451,27 @@ value (e.g., ``Time(['2000-1-1'])``) or an array containing one scalar
 `astropy.time.Time` object (e.g., ``[Time('2000-1-1')]``).
 
 Let's say that you created `astroplan.FixedTarget` objects for Polaris, Altair,
-Vega and Deneb.  To plot a map of the sky::
+Vega and Deneb.  To plot a map of the sky:
 
-    observe_time = Time(['2015-03-15 15:30:00'])
+.. code-block:: python
 
-    polaris_style = {color': 'k'}
-    vega_style = {'color': 'g'}
-    deneb_style = {'color': 'r'}
+    >>> import matplotlib.pyplot as plt
+    >>> from astropy.time import Time
+    >>> from astroplan.plots import plot_sky
 
-    plot_sky(polaris, observer, observe_time, style_kwargs=polaris_style)
-    plot_sky(altair, observer, observe_time)
-    plot_sky(vega, observer, observe_time, style_kwargs=vega_style)
-    plot_sky(deneb, observer, observe_time, style_kwargs=deneb_style)
+    >>> observe_time = Time(['2015-03-15 15:30:00'])
 
-    # Note that you don't need this code block to produce the plot.
-    # It reduces the plot size for the documentation.
-    ax = plt.gca()
-    box = ax.get_position()
-    ax.set_position([box.x0, box.y0, box.width * 0.75, box.height * 0.75])
+    >>> polaris_style = {color': 'k'}
+    >>> vega_style = {'color': 'g'}
+    >>> deneb_style = {'color': 'r'}
 
-    plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
-    plt.show()
+    >>> plot_sky(polaris, observer, observe_time, style_kwargs=polaris_style)
+    >>> plot_sky(altair, observer, observe_time)
+    >>> plot_sky(vega, observer, observe_time, style_kwargs=vega_style)
+    >>> plot_sky(deneb, observer, observe_time, style_kwargs=deneb_style)
+
+    >>> plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
+    >>> plt.show()
 
 .. warning::
 
@@ -516,17 +544,22 @@ Showing movement over time
 If you want to see how your targets move over time, you need to explicitly
 specify every instance in time.
 
-Say I want to know how Altair moves in the sky over a 9-hour period::
+Say I want to know how Altair moves in the sky over a 9-hour period:
 
-    import numpy as np
+.. code-block:: python
 
-    observe_time = Time('2015-03-15 17:00:00')
-    observe_time = observe_time + np.linspace(-4, 5, 10)*u.hour
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> import astropy.units as u
+    >>> from astroplan.plots import plot_sky
 
-    plot_sky(altair, observer, observe_time)
+    >>> observe_time = Time('2015-03-15 17:00:00')
+    >>> observe_time = observe_time + np.linspace(-4, 5, 10)*u.hour
 
-    plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
-    plt.show()
+    >>> plot_sky(altair, observer, observe_time)
+
+    >>> plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
+    >>> plt.show()
 
 .. plot::
 
@@ -594,9 +627,9 @@ Setting style options
 +++++++++++++++++++++
 
 The default marker for `plot_sky` is a circle and the default label (should you
-choose to display a legend) is the name contained in the `Target` object.  You
-can change the *marker*, *color*, *label* and other plotting properties by
-setting the *style_kwargs* option, in the same way shown for the
+choose to display a legend) is the name contained in the `astroplan.Target`
+object.  You can change the *marker*, *color*, *label* and other plotting
+properties by setting the *style_kwargs* option, in the same way shown for the
 :ref:`time-dependent plots <plots_style>`.
 
 One situation in which this is particularly useful is the plotting of guide
@@ -616,15 +649,20 @@ the plot, and South at the bottom, with azimuth increasing counter-clockwise
 
 You can't change the position of North or South (either in the actual plotting
 of the data, or the labels), but you can "flip" East/West by changing the
-direction in which azimuth increases via the *north_to_east_ccw* option::
+direction in which azimuth increases via the *north_to_east_ccw* option:
 
-    guide_style = {'marker': '*'}
+.. code-block:: python
 
-    plot_sky(polaris, observer, observe_time, style_kwargs=guide_style)
-    plot_sky(altair, observer, observe_time, north_to_east_ccw=False)
+    >>> import matplotlib.pyplot as plt
+    >>> from astroplan.plots import plot_sky
 
-    plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
-    plt.show()
+    >>> guide_style = {'marker': '*'}
+
+    >>> plot_sky(polaris, observer, observe_time, snorth_to_east_ccw=False, style_kwargs=guide_style)
+    >>> plot_sky(altair, observer, observe_time, north_to_east_ccw=False)
+
+    >>> plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
+    >>> plt.show()
 
 .. plot::
 
@@ -683,16 +721,20 @@ particular telescope setup.
 To do this, set *az_label_offset* equal to the number of degrees by which you
 wish to rotate the labels.  By default, *az_label_offset* is set to 0 degrees.
 A positive offset is in the same direction as azimuth increase (see the
-*north_to_east_ccw* option)::
+*north_to_east_ccw* option):
 
-    guide_style = {'marker': '*'}
+.. code-block:: python
 
-    plot_sky(polaris, observer, observe_time, style_kwargs=guide_style,
-             az_label_offset=180.0*u.deg)
-    plot_sky(altair, observer, observe_time, az_label_offset=180.0*u.deg)
+    >>> import matplotlib.pyplot as plt
+    >>> from astroplan.plots import plot_sky
 
-    plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
-    plt.show()
+    >>> guide_style = {'marker': '*'}
+
+    >>> plot_sky(polaris, observer, observe_time, style_kwargs=guide_style, az_label_offset=180.0*u.deg)
+    >>> plot_sky(altair, observer, observe_time, az_label_offset=180.0*u.deg)
+
+    >>> plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
+    >>> plt.show()
 
 .. plot::
 
@@ -757,16 +799,20 @@ A positive offset is in the same direction as azimuth increase (see the
     that your alt/az data does not coincide with the definition of altazimuth
     (local horizon) coordinate system.
 
-You can turn off the grid lines by setting the *grid* option to *False*::
+You can turn off the grid lines by setting the *grid* option to *False*:
 
-    guide_style = {'marker': '*'}
+.. code-block:: python
 
-    plot_sky(polaris, observer, observe_time, style_kwargs=guide_style,
-             grid=False)
-    plot_sky(altair, observer, observe_time, grid=False)
+    >>> import matplotlib.pyplot as plt
+    >>> from astroplan.plots import plot_sky
 
-    plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
-    plt.show()
+    >>> guide_style = {'marker': '*'}
+
+    >>> plot_sky(polaris, observer, observe_time, style_kwargs=guide_style, grid=False)
+    >>> plot_sky(altair, observer, observe_time, grid=False)
+
+    >>> plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
+    >>> plt.show()
 
 .. plot::
 
@@ -831,22 +877,22 @@ You can easily change other plot attributes by acting on the returned
 `matplotlib.axes.Axes` object or via `matplotlib.pyplot` calls (e.g.,
 `plt.figure`, `plt.rc`, etc.).
 
-For instance, you can increase the size of your plot and its font::
+For instance, you can increase the size of your plot and its font:
 
-    # Set the figure size/font before you issue the plotting command.
-    plt.figure(figsize=(8,6))
-    plt.rc('font', size=14)
+.. code-block:: python
 
-    guide_style = {'marker': '*'}
+    >>> # Set the figure size/font before you issue the plotting command.
+    >>> plt.figure(figsize=(8,6))
+    >>> plt.rc('font', size=14)
 
-    plot_sky(polaris, observer, observe_time, style_kwargs=guide_style)
-    plot_sky(altair, observer, observe_time)
+    >>> plot_sky(polaris, observer, observe_time)
+    >>> plot_sky(altair, observer, observe_time)
 
-    plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
-    plt.show()
+    >>> plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
+    >>> plt.show()
 
-    # Change font size back to default once done plotting.
-    plt.rc('font', size=12)
+    >>> # Change font size back to default once done plotting.
+    >>> plt.rc('font', size=12)
 
 :ref:`Return to Top <plots>`
 
@@ -860,41 +906,40 @@ named axis, assuming that you have created the appropriate type for the
 particular plot you want.
 
 We can explicitly give a name to the `matplotlib.axes.Axes` object returned
-by `plot_sky` when plotting Polaris and reuse it to plot Altair::
+by `plot_sky` when plotting Polaris and reuse it to plot Altair:
 
-    observe_time = Time(['2015-03-15 15:30:00'])
+.. code-block:: python
 
-    guide_style = {'marker': '*'}
-
-    my_ax = plot_sky(polaris, observer, observe_time, style_kwargs=guide_style)
-    plot_sky(altair, observer, observe_time, my_ax)
-
-    plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
-    plt.show()
+    >>> my_ax = plot_sky(polaris, observer, observe_time, style_kwargs=guide_style)
+    >>> plot_sky(altair, observer, observe_time, my_ax)
 
 We can also create a `matplotlib.axes.Axes` object entirely outside of
-`plot_sky`, then pass it in::
+`plot_sky`, then pass it in:
 
-    my_ax = plt.gca(projection='polar')
-    plot_sky(polaris, observer, observe_time, my_ax)
+.. code-block:: python
 
-    plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
-    plt.show()
+    >>> my_ax = plt.gca(projection='polar')
+    >>> plot_sky(polaris, observer, observe_time, my_ax)
 
 Passing in named `matplotlib.axes.Axes` objects comes in handy when you want to
-make multiple plots::
+make multiple plots:
 
-    my_ax = plot_sky(polaris, observer, observe_time, style_kwargs=polaris_style)
-    plot_sky(altair, observer, observe_time, my_ax, style_kwargs=altair_style)
-    plt.legend(loc='center left', bbox_to_anchor=(1.3, 0.5))
-    # Note that this plt.show (or another action, such as saving a figure) is
-    # critical in maintaining two separate plots.
-    plt.show()
+.. code-block:: python
 
-    other_ax = plot_sky(vega, observer, observe_time, style_kwargs=vega_style)
-    plot_sky(deneb, observer, observe_time, other_ax, style_kwargs=deneb_style)
-    plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
-    plt.show()
+    >>> from astroplan.plots import plot_sky
+    >>> import matplotlib.pyplot as plt
+
+    >>> my_ax = plot_sky(polaris, observer, observe_time, style_kwargs=polaris_style)
+    >>> plot_sky(altair, observer, observe_time, my_ax, style_kwargs=altair_style)
+    >>> plt.legend(loc='center left', bbox_to_anchor=(1.3, 0.5))
+
+    >>> # Note that this plt.show (or another action, such as saving a figure) is critical in maintaining two separate plots.
+    >>> plt.show()
+
+    >>> other_ax = plot_sky(vega, observer, observe_time, style_kwargs=vega_style)
+    >>> plot_sky(deneb, observer, observe_time, other_ax, style_kwargs=deneb_style)
+    >>> plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
+    >>> plt.show()
 
 .. plot::
 
@@ -949,6 +994,7 @@ make multiple plots::
     ax.set_position([box.x0, box.y0, box.width * 0.75, box.height * 0.75])
 
     plt.legend(loc='center left', bbox_to_anchor=(1.3, 0.5))
+
     # Note that this plt.show (or another action, such as saving a figure) is
     # critical in maintaining two separate plots.
     plt.show()

--- a/docs/tutorials/plots.rst
+++ b/docs/tutorials/plots.rst
@@ -53,21 +53,21 @@ These take, at minimum, `astroplan.Observer`, `astroplan.FixedTarget` and
 
 Airmass vs time plots are made the following way:
 
-.. doctest-skip::
+.. code-block:: python
 
     >>> from astroplan.plots import plot_airmass
 
-    >>> plot_airmass(target, observer, time)
+    >>> plot_airmass(target, observer, time) # doctest: +SKIP
 
 .. _plots_parallactic:
 
 Parallactic angle vs time plots are made the following way:
 
-.. doctest-skip::
+.. code-block:: python
 
     >>> from astroplan.plots import plot_airmass
 
-    >>> plot_parallactic(target, observer, time)
+    >>> plot_parallactic(target, observer, time) # doctest: +SKIP
 
 Below are general guidelines for working with time-dependent plots in
 `astroplan`.  Examples use airmass but apply to parallactic angle as well.

--- a/docs/tutorials/plots.rst
+++ b/docs/tutorials/plots.rst
@@ -2,6 +2,8 @@
 
 .. _plots:
 
+.. doctest-skip-all
+
 ***********************
 Plotting with Astroplan
 ***********************
@@ -57,7 +59,7 @@ Airmass vs time plots are made the following way:
 
     >>> from astroplan.plots import plot_airmass
 
-    >>> plot_airmass(target, observer, time) # doctest: +SKIP
+    >>> plot_airmass(target, observer, time)
 
 .. _plots_parallactic:
 
@@ -67,7 +69,7 @@ Parallactic angle vs time plots are made the following way:
 
     >>> from astroplan.plots import plot_airmass
 
-    >>> plot_parallactic(target, observer, time) # doctest: +SKIP
+    >>> plot_parallactic(target, observer, time)
 
 Below are general guidelines for working with time-dependent plots in
 `astroplan`.  Examples use airmass but apply to parallactic angle as well.

--- a/docs/tutorials/plots.rst
+++ b/docs/tutorials/plots.rst
@@ -53,7 +53,7 @@ These take, at minimum, `astroplan.Observer`, `astroplan.FixedTarget` and
 
 Airmass vs time plots are made the following way:
 
-.. code-block:: python
+.. doctest-skip::
 
     >>> from astroplan.plots import plot_airmass
 
@@ -63,7 +63,7 @@ Airmass vs time plots are made the following way:
 
 Parallactic angle vs time plots are made the following way:
 
-.. code-block:: python
+.. doctest-skip::
 
     >>> from astroplan.plots import plot_airmass
 

--- a/docs/tutorials/summer_triangle.rst
+++ b/docs/tutorials/summer_triangle.rst
@@ -196,7 +196,7 @@ can plot it over the course of the night (for more on plotting see :doc:`plots`)
     >>> from astroplan.plots import plot_airmass
     >>> import matplotlib.pyplot as plt
 
-    >>> plot_airmass(altair, subaru, time)
+    >>> plot_airmass(altair, subaru, time) # doctest: +SKIP
     >>> plot_airmass(vega, subaru, time)
     >>> plot_airmass(deneb, subaru, time)
 

--- a/docs/tutorials/summer_triangle.rst
+++ b/docs/tutorials/summer_triangle.rst
@@ -138,7 +138,7 @@ indeed those for tonight):
     >>> sunset_tonight.iso
     '2015-06-16 04:59:11.267'
 
-This is '2015-06-15 18:49:11.267' in the Hawaii time zone (that's where Subaru
+This is '2015-06-15 18:59:11.267' in the Hawaii time zone (that's where Subaru
 is).
 
 .. code-block:: python

--- a/docs/tutorials/summer_triangle.rst
+++ b/docs/tutorials/summer_triangle.rst
@@ -1,7 +1,5 @@
 .. _summer_triangle_tutorial:
 
-.. doctest-skip-all
-
 .. todo::
 
     Add section on moon phases, illumination fraction, etc.
@@ -38,45 +36,38 @@ Defining Objects
 Say we want to look at the Summer Triangle (Altair, Deneb, and Vega) using the
 Subaru Telescope.
 
-First, we define our `Observer` object::
+First, we define our `Observer` object:
 
-    import astropy.units as u
-    from astropy.coordinates import EarthLocation
-    from pytz import timezone
-    from astroplan import Observer
+.. code-block:: python
 
-    longitude = '-155d28m48.900s'
-    latitude = '+19d49m42.600s'
-    elevation = 4163 * u.m
-    location = EarthLocation.from_geodetic(longitude, latitude, elevation)
+    >>> from astroplan import Observer
 
-    subaru = Observer(name='Subaru Telescope',
-                   location=location,
-                   timezone=timezone('US/Hawaii'),
-                   description="Subaru Telescope on Mauna Kea, Hawaii")
+    >>> subaru = Observer.at_site('subaru')
 
 Then, we define our `Target` objects (`FixedTarget`'s in this case, since the
 Summer Triangle is fixed with respect to the celestial sphere if we ignore the
-relatively small proper motion)::
+relatively small proper motion):
 
-    from astropy.coordinates import SkyCoord
-    from astroplan import FixedTarget
+.. code-block:: python
 
-    coordinates = SkyCoord('19h50m47.6s', '+08d52m12.0s', frame='icrs')
-    altair = FixedTarget(name='Altair', coord=coordinates)
+    >>> from astropy.coordinates import SkyCoord
+    >>> from astroplan import FixedTarget
 
-    coordinates = SkyCoord('18h36m56.5s', '+38d47m06.6s', frame='icrs')
-    vega = FixedTarget(name='Vega', coord=coordinates)
+    >>> coordinates = SkyCoord('19h50m47.6s', '+08d52m12.0s', frame='icrs')
+    >>> altair = FixedTarget(name='Altair', coord=coordinates)
 
-    coordinates = SkyCoord('20h41m25.9s', '+45d16m49.3s', frame='icrs')
-    deneb = FixedTarget(name='Deneb', coord=coordinates)
+    >>> coordinates = SkyCoord('18h36m56.5s', '+38d47m06.6s', frame='icrs')
+    >>> vega = FixedTarget(name='Vega', coord=coordinates)
+
+    >>> coordinates = SkyCoord('20h41m25.9s', '+45d16m49.3s', frame='icrs')
+    >>> deneb = FixedTarget(name='Deneb', coord=coordinates)
 
 We also have to define a `Time` (in UTC) at which we wish to observe.  Here, we
 pick 2AM local time, which is noon UTC during the summer::
 
-    from astropy.time import Time
+    >>> from astropy.time import Time
 
-    time = Time('2015-06-16 12:00:00')
+    >>> time = Time('2015-06-16 12:00:00')
 
 :ref:`Return to Top <summer_triangle_tutorial>`
 
@@ -92,13 +83,13 @@ is down?
 .. code-block:: python
 
     >>> subaru.target_is_up(time, altair)
-    array(True, dtype=bool)
+    True
 
     >>> subaru.target_is_up(time, vega)
-    array(True, dtype=bool)
+    True
 
     >>> subaru.target_is_up(time, deneb)
-    array(True, dtype=bool)
+    True
 
 ...They are!
 
@@ -115,21 +106,27 @@ However, we may want to find a window of time for tonight during which all
 three of our targets are above the horizon *and* the Sun is below the horizon
 (let's worry about light pollution from the Moon later).
 
-Let's define the window of time during which all targets are above the horizon::
+Let's define the window of time during which all targets are above the horizon.
+Note that because of the precision limitations of rise/set calculations
+(altitudes at these times won't equal precisely zero, but will be off by a few
+arc seconds), we'll manually adjust rise/set times by a few minutes.
 
-    altair_rise = subaru.target_rise_time(time, altair)
-    altair_set = subaru.target_set_time(time, altair)
+.. code-block:: python
 
-    vega_rise = subaru.target_rise_time(time, vega)
-    vega_set = subaru.target_set_time(time, vega)
+    >>> import numpy as np
+    >>> import astropy.units as u
 
-    deneb_rise = subaru.target_rise_time(time, deneb)
-    deneb_set = subaru.target_set_time(time, deneb)
+    >>> altair_rise = subaru.target_rise_time(time, altair) + 5*u.minute
+    >>> altair_set = subaru.target_set_time(time, altair) - 5*u.minute
 
-    import numpy as np
+    >>> vega_rise = subaru.target_rise_time(time, vega) + 5*u.minute
+    >>> vega_set = subaru.target_set_time(time, vega) - 5*u.minute
 
-    all_up_start = np.max([altair_rise, vega_rise, deneb_rise])
-    all_up_end = np.min([altair_set, vega_set, deneb_set])
+    >>> deneb_rise = subaru.target_rise_time(time, deneb) + 5*u.minute
+    >>> deneb_set = subaru.target_set_time(time, deneb) - 5*u.minute
+
+    >>> all_up_start = np.max([altair_rise, vega_rise, deneb_rise])
+    >>> all_up_end = np.min([altair_set, vega_set, deneb_set])
 
 Now, let's find sunset and sunrise for tonight (and confirm that they are
 indeed those for tonight):
@@ -139,18 +136,19 @@ indeed those for tonight):
     >>> sunset_tonight = subaru.sun_set_time(time, which='nearest')
 
     >>> sunset_tonight.iso
-    '2015-06-16 04:59:12.610'
+    '2015-06-16 04:59:11.267'
 
-This is 2015-06-15 18:49:12.610 in the Hawaii time zone (that's where Subaru is).
+This is '2015-06-15 18:49:11.267' in the Hawaii time zone (that's where Subaru
+is).
 
 .. code-block:: python
 
     >>> sunrise_tonight = subaru.sun_rise_time(time, which='nearest')
 
     >>> sunrise_tonight.iso
-    '2015-06-16 15:47:36.466'
+    '2015-06-16 15:47:35.822'
 
-Or 2015-06-16 05:47:36.466 Hawaii time.
+This is '2015-06-16 05:47:35.822' Hawaii time.
 
 Sunset and sunrise check out, so now we define the limits of our observation
 window:
@@ -158,18 +156,16 @@ window:
 .. code-block:: python
 
     >>> start = np.max([sunset_tonight, all_up_start])
-
     >>> start.iso
-    '2015-06-16 06:23:40.991'
+    '2015-06-16 06:28:40.126'
 
     >>> end = np.min([sunrise_tonight, all_up_end])
-
     >>> end.iso
-    '2015-06-16 15:47:36.466'
+    '2015-06-16 15:47:35.822'
 
 So, our targets will be visible (as we've defined it above) from
-2015-06-15 20:23:40.991 to 2015-06-16 05:47:36.466 Hawaii time.  Depending on
-our observation goals, this window of time may be good enough for preliminary
+'2015-06-15 20:28:40.126' to '2015-06-16 05:47:35.822' Hawaii time.  Depending
+on our observation goals, this window of time may be good enough for preliminary
 planning, or we may want to optimize our observational conditions.  If the
 latter is the case, go on to the Optimal Observation Time section (immediately
 below).
@@ -468,9 +464,8 @@ targets lay in the sky::
 
     from astropy.time import Time
 
-    # Here we need to add a second to our start time so that all objects show up.
-    start = Time('2015-06-16 06:23:40.991') + 1 * u.second
-    end = Time('2015-06-16 15:47:36.466')
+    start = Time('2015-06-16 06:28:40.126')
+    end = Time('2015-06-16 15:47:35.822')
 
     from astroplan.plots import plot_sky
     import matplotlib.pyplot as plt
@@ -548,9 +543,8 @@ We can also show how our targets move over time during the night in question::
     from astroplan.plots import plot_sky
     import matplotlib.pyplot as plt
 
-    # Here we need to add a second to our start time so that all objects show up.
-    start = Time('2015-06-16 06:23:40.991') + 1 * u.second
-    end = Time('2015-06-16 15:47:36.466')
+    start = Time('2015-06-16 06:28:40.126')
+    end = Time('2015-06-16 15:47:35.822')
 
     time_window = start + (end - start) * np.linspace(0, 1, 10)
 

--- a/docs/tutorials/summer_triangle.rst
+++ b/docs/tutorials/summer_triangle.rst
@@ -98,7 +98,7 @@ What if we weren't sure if the Sun is down at this time:
 .. code-block:: python
 
     >>> subaru.is_night(time)
-    array([ True], dtype=bool)
+    True
 
 ...It is!
 
@@ -184,17 +184,19 @@ Airmass
 -------
 
 To get a general idea of our targets' airmass on the night of observation, we
-can plot it over the course of the night (for more on plotting see :doc:`plots`)::
+can plot it over the course of the night (for more on plotting see :doc:`plots`):
 
-    from astroplan.plots import plot_airmass
-    import matplotlib.pyplot as plt
+.. code-block:: python
 
-    plot_airmass(altair, subaru, time)
-    plot_airmass(vega, subaru, time)
-    plot_airmass(deneb, subaru, time)
+    >>> from astroplan.plots import plot_airmass
+    >>> import matplotlib.pyplot as plt
 
-    plt.legend(loc=1, bbox_to_anchor=(1, 1))
-    plt.show()
+    >>> plot_airmass(altair, subaru, time)
+    >>> plot_airmass(vega, subaru, time)
+    >>> plot_airmass(deneb, subaru, time)
+
+    >>> plt.legend(loc=1, bbox_to_anchor=(1, 1))
+    >>> plt.show()
 
 .. plot::
 
@@ -256,13 +258,13 @@ use the ``AltAz`` frame:
 .. code-block:: python
 
     >>> subaru.altaz(time, altair).secz
-    1.030256
+    <Quantity 1.0302347952130682>
 
     >>> subaru.altaz(time, vega).secz
-    1.0690128
+    <Quantity 1.0690421636016616>
 
     >>> subaru.altaz(time, deneb).secz
-    1.1677464
+    <Quantity 1.167753811648361>
 
 Behind the scenes here, ``subaru.altaz(time, altair)`` is actually creating an
 `astropy.coordinates.AltAz` object in the `AltAz` frame, so if you know how to
@@ -274,16 +276,19 @@ Parallactic Angle
 
 To get a general idea of our targets' parallactic angle on the night of
 observation, we can make another plot (again, see :doc:`plots` for more on
-customizing plots and the like)::
+customizing plots and the like):
 
-    from astroplan.plots import plot_parallactic
+.. code-block:: python
 
-    plot_parallactic(altair, subaru, time)
-    plot_parallactic(vega, subaru, time)
-    plot_parallactic(deneb, subaru, time)
+    >>> import matplotlib.pyplot as plt
+    >>> from astroplan.plots import plot_parallactic
 
-    plt.legend(loc=2)
-    plt.show()
+    >>> plot_parallactic(altair, subaru, time)
+    >>> plot_parallactic(vega, subaru, time)
+    >>> plot_parallactic(deneb, subaru, time)
+
+    >>> plt.legend(loc=2)
+    >>> plt.show()
 
 .. plot::
 
@@ -333,18 +338,19 @@ We can also calculate the parallactic angle directly:
 .. code-block:: python
 
     >>> subaru.parallactic_angle(time, altair)
-    <Angle -0.6405821008131366 rad>
+    <Angle -0.6404957821112053 rad>
 
     >>> subaru.parallactic_angle(time, vega)
-    <Angle -0.46529763909549615 rad>
+    <Angle -0.46542183982024 rad>
 
     >>> subaru.parallactic_angle(time, deneb)
-    <Angle 0.7298709840493603 rad>
+    <Angle 0.7297067855978494 rad>
 
 The `~astropy.coordinates.Angle` objects resulting from the calls to
 ``parallactic_angle()`` are subclasses of the `astropy.units.Quantity` class, so
 they can do everything a `~astropy.units.Quantity` can do - basically they work
 like numbers with attached units, and keep track of units so you don't have to.
+
 For more on the many things you can do with these, take a look at the `astropy`
 documentation or tutorials.  For now the  most useful thing is to know is that
 ``angle.degree``,``angle.hourangle``, and  ``angle.radian`` give you back Python
@@ -372,11 +378,11 @@ We could also look at the Moon's alt/az coordinates:
 
 .. code-block:: python
 
-    >>> print(subaru.moon_altaz(time).alt)
-    −45∘05′18.2435′′
+    >>> subaru.moon_altaz(time).alt
+    <Latitude -45.08860929634166 deg>
 
-    >>> print(subaru.moon_altaz(time).az)
-    34∘35′57.5413′′
+    >>> subaru.moon_altaz(time).az
+    <Longitude 34.605498354422686 deg>
 
 It looks like the Moon is well below the horizon at the time we picked before,
 but we should check to see if it will be out during the window of time our
@@ -387,11 +393,12 @@ targets will be visible (again--as defined at the beginning of this tutorial):
     >>> visible_time = start + (end - start)*np.linspace(0, 1, 20)
 
     >>> subaru.moon_altaz(visible_time).alt
-    [−24∘15′08.8308′′ −29∘49′04.6286′′ −35∘03′43.449′′ −39∘53′16.0653′′
-    −44∘09′59.8904′′ −47∘44′08.5089′′ −50∘24′19.9784′′ −51∘59′18.4053′′
-    −52∘20′53.9214′′ −51∘27′04.0998′′ −49∘22′46.0578′′ −46∘17′54.7431′′
-    −42∘24′06.7653′′ −37∘52′10.4174′′ −32∘50′59.3228′′ −27∘27′24.8625′′
-    −21∘46′34.5241′′ −15∘52′15.6116′′ −9∘47′16.3944′′ −2∘11′39.571′′]
+    <Latitude [-25.21127325,-30.68088873,-35.82145644,-40.53415037,
+               -44.68898859,-48.12296182,-50.64971858,-52.08946099,
+               -52.31849772,-51.31548444,-49.17038499,-46.04862654,
+               -42.13887599,-37.61479774,-32.61875342,-27.26048709,
+               -21.62215227,-15.76463668, -9.73313141, -2.19408792] deg>
+
 
 Looks like the Moon will be below the horizon during the entire time.
 
@@ -405,33 +412,35 @@ Sky Charts
 Now that we've determined the best times to observe our targets on the night in
 question, let's take a look at the positions of our objects in the sky.
 
-We can use `plot_sky` as a sanity check on our target's positions or even just
-to better visualize our observation run.
+We can use `astroplan.plots.plot_sky` as a sanity check on our target's
+positions or even just to better visualize our observation run.
 
 Let's take the `start` and `end` of the time window we determined
 :ref:`earlier <summer_triangle-observable>` (using the most basic definition
 of "visible" targets, above the horizon when the sun is down), and see where our
-targets lay in the sky::
+targets lay in the sky:
 
-    from astroplan.plots import plot_sky
-    import matplotlib.pyplot as plt
+.. code-block:: python
 
-    altair_style = {'color': 'r'}
-    deneb_style = {'color': 'g'}
+    >>> from astroplan.plots import plot_sky
+    >>> import matplotlib.pyplot as plt
 
-    plot_sky(altair, subaru, start, style_kwargs=altair_style)
-    plot_sky(vega, subaru, start)
-    plot_sky(deneb, subaru, start, style_kwargs=deneb_style)
+    >>> altair_style = {'color': 'r'}
+    >>> deneb_style = {'color': 'g'}
 
-    plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
-    plt.show()
+    >>> plot_sky(altair, subaru, start, style_kwargs=altair_style)
+    >>> plot_sky(vega, subaru, start)
+    >>> plot_sky(deneb, subaru, start, style_kwargs=deneb_style)
 
-    plot_sky(altair, subaru, end, style_kwargs=altair_style)
-    plot_sky(vega, subaru, end)
-    plot_sky(deneb, subaru, end, style_kwargs=deneb_style)
+    >>> plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
+    >>> plt.show()
 
-    plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
-    plt.show()
+    >>> plot_sky(altair, subaru, end, style_kwargs=altair_style)
+    >>> plot_sky(vega, subaru, end)
+    >>> plot_sky(deneb, subaru, end, style_kwargs=deneb_style)
+
+    >>> plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
+    >>> plt.show()
 
 .. plot::
 
@@ -501,14 +510,14 @@ targets lay in the sky::
 
 We can also show how our targets move over time during the night in question::
 
-    time_window = start + (end - start) * np.linspace(0, 1, 10) * u.hour
+    >>> time_window = start + (end - start) * np.linspace(0, 1, 10)
 
-    plot_sky(altair, subaru, time_window, style_kwargs=altair_style)
-    plot_sky(vega, subaru, time_window)
-    plot_sky(deneb, subaru, time_window, style_kwargs=deneb_style)
+    >>> plot_sky(altair, subaru, time_window, style_kwargs=altair_style)
+    >>> plot_sky(vega, subaru, time_window)
+    >>> plot_sky(deneb, subaru, time_window, style_kwargs=deneb_style)
 
-    plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
-    plt.show()
+    >>> plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
+    >>> plt.show()
 
 .. plot::
 

--- a/docs/tutorials/summer_triangle.rst
+++ b/docs/tutorials/summer_triangle.rst
@@ -8,14 +8,18 @@
 
     Update with constraints when available?
 
-    Rise/set times currently return altitudes just below the horizon by a few
-    arcseconds.  Need to clarify this and fix sky plot examples.
-
     Show users how to create/use Time objects in their own timezone.
 
 *****************************
 Observing the Summer Triangle
 *****************************
+
+.. note::
+
+    Your calculated rise/set and other times may differ slightly from those in
+    this tutorial, on the order of ~1 second.  This is a normal variance in
+    precision due to several factors, including varying :ref:`IERS tables <iers>`
+    and machine architecture.
 
 Contents
 ========
@@ -135,7 +139,7 @@ indeed those for tonight):
 
     >>> sunset_tonight = subaru.sun_set_time(time, which='nearest')
 
-    >>> sunset_tonight.iso
+    >>> sunset_tonight.iso # doctest: +SKIP
     '2015-06-16 04:59:11.267'
 
 This is '2015-06-15 18:59:11.267' in the Hawaii time zone (that's where Subaru

--- a/docs/tutorials/summer_triangle.rst
+++ b/docs/tutorials/summer_triangle.rst
@@ -111,6 +111,7 @@ three of our targets are above the horizon *and* the Sun is below the horizon
 (let's worry about light pollution from the Moon later).
 
 Let's define the window of time during which all targets are above the horizon.
+
 Note that because of the precision limitations of rise/set calculations
 (altitudes at these times won't equal precisely zero, but will be off by a few
 arc seconds), we'll manually adjust rise/set times by a few minutes.
@@ -149,7 +150,7 @@ is).
 
     >>> sunrise_tonight = subaru.sun_rise_time(time, which='nearest')
 
-    >>> sunrise_tonight.iso
+    >>> sunrise_tonight.iso # doctest: +SKIP
     '2015-06-16 15:47:35.822'
 
 This is '2015-06-16 05:47:35.822' Hawaii time.
@@ -160,11 +161,11 @@ window:
 .. code-block:: python
 
     >>> start = np.max([sunset_tonight, all_up_start])
-    >>> start.iso
+    >>> start.iso # doctest: +SKIP
     '2015-06-16 06:28:40.126'
 
     >>> end = np.min([sunrise_tonight, all_up_end])
-    >>> end.iso
+    >>> end.iso # doctest: +SKIP
     '2015-06-16 15:47:35.822'
 
 So, our targets will be visible (as we've defined it above) from


### PR DESCRIPTION
This comes from discussion with @eteq & @adrn about the need to be consistent with code block prompts (e.g. `>>>` at the beginning of every line) in the docs, as well as allowing doc tests to be run on those code blocks.