### PR TITLE
Set up Windows and Mac testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,11 +13,10 @@ environment:
 
   matrix:
 
-      # We test Python 2.6 and 3.4 because 2.6 is most likely to have issues in
-      # Python 2 (if 2.6 passes, 2.7 virtually always passes) and Python 3.4 is
-      # the latest Python 3 release.
+      # Note that we don't support Python 2.6 in astroplan,
+      # so we test Python 2.7 (whereas Astropy tests on 2.6)
 
-      - PYTHON_VERSION: "2.6"
+      - PYTHON_VERSION: "2.7"
         NUMPY_VERSION: "1.9.1"
       - PYTHON_VERSION: "3.4"
         NUMPY_VERSION: "1.9.1"
@@ -41,6 +40,7 @@ install:
 
     # Install specified version of numpy and dependencies
     - "conda install -q --yes numpy=%NUMPY_VERSION% pytest Cython scipy astropy beautiful-soup jinja2 pyyaml"
+    - "conda install -q --yes numpy=%NUMPY_VERSION% matplotlib nose pytz"
     - "pip install pytest-mpl"
 
 # Not a .NET project, we build SunPy in the install step instead
@@ -48,4 +48,3 @@ build: false
 
 test_script:
   - "%CMD_IN_ENV% python setup.py test"
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,4 +75,3 @@ Contributors
 * Eric Jeschke
 * Adrian Price-Whelan
 * Erik Tollerud
-

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,7 +9,8 @@ Installation
 Requirements
 ============
 
-**astroplan** requires Python 2.7 or 3.3+ (2.6 and 3.2 or earlier are not
+**astroplan** works on Linux, Mac OS X and Windows.
+It requires Python 2.7 or 3.3+ (2.6 and 3.2 or earlier are not
 supported) as well as the following packages:
 
 * `Numpy`_


### PR DESCRIPTION
We should improve the Astropy continuous integration (CI) setup:

- [x] Windows testing via Appveyor
- [x] Mac testing on travis-ci
- [x] Switch to container-based builds on travis-ci

Packages that do this to look at for examples are [astropy](https://github.com/astropy/astropy) or [photutils](https://github.com/astropy/photutils)

@eteq or @adrn – Is this something you have time for? Or should we ask Brett or Jazmin if they are interested in setting this up? Alternatively I could do this next week.