### PR TITLE
Fix pytest-mpl and pytest usage

### DIFF
--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -20,13 +20,6 @@ fi
 # CORE DEPENDENCIES
 conda install --yes pytest Cython jinja2 psutil pytz
 
-# For now testing requires matplotlib and pytest-mpl
-# TODO: make this optional if possible
-# https://github.com/astropy/astroplan/issues/86
-# https://github.com/astropy/astroplan/pull/83
-conda install --yes matplotlib nose
-pip install pytest-mpl
-
 # NUMPY
 if [[ $NUMPY_VERSION == dev ]]
 then
@@ -53,7 +46,7 @@ if $OPTIONAL_DEPS
 then
   # Note: nose is required to run the matplotlib image comparison tests
   $CONDA_INSTALL matplotlib nose
-  pip install pyephem
+  pip install pyephem pytest-mpl
 fi
 
 # DOCUMENTATION DEPENDENCIES

--- a/astroplan/conftest.py
+++ b/astroplan/conftest.py
@@ -21,3 +21,14 @@ except NameError:  # needed to support Astropy < 1.0
 # within the tests
 from .utils import _mock_remote_data
 _mock_remote_data()
+
+def pytest_configure(config):
+    try:
+        import matplotlib
+        HAS_MATPLOTLIB = True
+    except ImportError:
+        HAS_MATPLOTLIB = False
+
+    if HAS_MATPLOTLIB and config.pluginmanager.hasplugin('mpl'):
+            config.option.mpl = True
+            config.option.mpl_baseline_path = 'astroplan/plots/tests/baseline_images'

--- a/astroplan/conftest.py
+++ b/astroplan/conftest.py
@@ -25,10 +25,11 @@ _mock_remote_data()
 def pytest_configure(config):
     try:
         import matplotlib
-        HAS_MATPLOTLIB = True
+        import nose  # needed for the matplotlib testing tools
+        HAS_MATPLOTLIB_AND_NOSE = True
     except ImportError:
-        HAS_MATPLOTLIB = False
+        HAS_MATPLOTLIB_AND_NOSE = False
 
-    if HAS_MATPLOTLIB and config.pluginmanager.hasplugin('mpl'):
+    if HAS_MATPLOTLIB_AND_NOSE and config.pluginmanager.hasplugin('mpl'):
             config.option.mpl = True
             config.option.mpl_baseline_path = 'astroplan/plots/tests/baseline_images'

--- a/astroplan/plots/sky.py
+++ b/astroplan/plots/sky.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import matplotlib.pyplot as plt
 import numpy as np
 import astropy.units as u
 from astropy.time import Time
@@ -94,6 +93,7 @@ def plot_sky(target, observer, time, ax=None, style_kwargs=None,
         N/E/S/W are being decoupled from the definition of azimuth
         (North from az = 0 deg., East from az = 90 deg., etc.).
     """
+    import matplotlib.pyplot as plt
 
     # Set up axes & plot styles if needed.
     if ax is None:

--- a/astroplan/plots/tests/test_sky.py
+++ b/astroplan/plots/tests/test_sky.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-import pytest
+from astropy.tests.helper import pytest
 
 try:
     import matplotlib

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import matplotlib.pyplot as plt
 import numpy as np
 import astropy.units as u
 from astropy.time import Time
@@ -66,6 +65,7 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None):
         1) Timezones?
         2) Dark plot option.
     """
+    import matplotlib.pyplot as plt
 
     # Set up plot axes and style if needed.
     if ax is None:
@@ -164,6 +164,7 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None):
         1) dark_plot style
         2) observe_timezone -- update with info from observer?
     """
+    import matplotlib.pyplot as plt
 
     # Set up plot axes and style if needed.
     if ax is None:

--- a/astroplan/tests/test_core.py
+++ b/astroplan/tests/test_core.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytz
 import datetime
-import pytest
+from astropy.tests.helper import pytest
 
 from ..sites import get_site
 from ..core import (FixedTarget, Observer, list_FixedTarget_to_SkyCoord,

--- a/astroplan/tests/test_moon.py
+++ b/astroplan/tests/test_moon.py
@@ -2,12 +2,11 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import pytest
-
 from ..core import Observer
 from astropy.time import Time
 from astropy.coordinates import EarthLocation
 import astropy.units as u
+from astropy.tests.helper import pytest
 from numpy.testing import assert_allclose
 
 try:

--- a/astroplan/tests/test_sites.py
+++ b/astroplan/tests/test_sites.py
@@ -5,7 +5,7 @@ from ..core import Observer
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.coordinates import Latitude, Longitude, EarthLocation
 import astropy.units as u
-import pytest
+from astropy.tests.helper import pytest
 import json
 
 def test_get_site():

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -54,6 +54,13 @@ configuration, start up python, and type::
 
 If there are no errors, you are good to go!
 
+.. note::
+	If you want to run the tests that access the internet, you'll need to
+	replace the last line above with ``astroplan.test(remote_data=True)`` and
+	have an active connection to the internet.  Also, if you want the tests
+	that check plotting to work, you need `Matplotlib`_, `pytest-mpl`_, and
+	`Nose`_.
+
 More
 ====
 

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -4,3 +4,5 @@
 .. _Numpy: http://www.numpy.org
 .. _Matplotlib: http://www.matplotlib.org
 .. _pytz: https://pypi.python.org/pypi/pytz/
+.. _pytest-mpl: https://pypi.python.org/pypi/pytest-mpl
+.. _Nose: https://nose.readthedocs.org

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ show-response = 1
 minversion = 2.2
 norecursedirs = build docs/_build
 doctest_plus = enabled
-addopts = --mpl --mpl-baseline-path=astroplan/plots/tests/baseline_images
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
This PR makes two different changes dealing with the testing suite: First, it fixes #86 by programmatically deciding to turn pytest-mpl on or off based on whether it's installed or not. (cc @cdeil for this.)  @astrofrog my want to weigh in on whether this is a recommended way or not, too, but I think we want to merge this ASAP to allow for 0.1 to go forward, even if we go with some better way in 0.2.

Second, it changes all ``import pytest`` statements to instead be ``from astropy.tests.helper import pytest``.  The reasoning for this is that we don't want ``pytest`` to be a necessary dependency for users to run the tests.  So using the pytest packaged with astropy lets us do this without having to include pytest ourselves.  Note that this machinery still allows use of any system- installed pytest by doing invoking the tests as ``ASTROPY_USE_SYSTEM_PYTEST=1 python setup.py test`` (cc @jberlanga and @bmorris3 because I think you both might have done ``import pytest`` simply because you didn't know about this option.)