### PR TITLE
Add tests with remote-data on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,15 +63,9 @@ matrix:
         # build (with latest numpy). We also note the code coverage on Python
         # 2.7.
         - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='test -V --coverage' OPTIONAL_DEPS=true
+          env: PYTHON_VERSION=2.7 SETUP_CMD='test --remote-data -V --coverage' OPTIONAL_DEPS=true
         - os: linux
-          env: PYTHON_VERSION=3.4 SETUP_CMD='test -V' OPTIONAL_DEPS=true
-
-        # Also try with remote-data option (and do optional_deps in case there's overlap there)
-        - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='test --remote-data -V' OPTIONAL_DEPS=true
-        - os: linux
-          env: PYTHON_VERSION=3.4 SETUP_CMD='test --remote-data-V' OPTIONAL_DEPS=true
+          env: PYTHON_VERSION=3.4 SETUP_CMD='test --remote-data -V' OPTIONAL_DEPS=true
 
         # Try older numpy versions
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,12 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.4 SETUP_CMD='test -V' OPTIONAL_DEPS=true
 
+        # Also try with remote-data option (and do optional_deps in case there's overlap there)
+        - os: linux
+          env: PYTHON_VERSION=2.7 SETUP_CMD='test --remote-data -V' OPTIONAL_DEPS=true
+        - os: linux
+          env: PYTHON_VERSION=3.4 SETUP_CMD='test --remote-data-V' OPTIONAL_DEPS=true
+
         # Try older numpy versions
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 SETUP_CMD='test -V'


### PR DESCRIPTION
This adds just adds two tests to the travis test matrix that have ``--remote-data`` turned on.  This is normally pretty safe on travis because it has to be connected to the internet anyway.