### PR TITLE
Harmonize warnings

### DIFF
--- a/astroplan/exceptions.py
+++ b/astroplan/exceptions.py
@@ -8,19 +8,22 @@ __all__ = ["TargetAlwaysUpWarning", "TargetNeverUpWarning",
            "OldEarthOrientationDataWarning", "PlotWarning",
            "PlotBelowHorizonWarning"]
 
-class TargetAlwaysUpWarning(AstropyWarning):
+class AstroplanWarning(AstropyWarning):
+    """Superclass for warnings used by astroplan"""
+
+class TargetAlwaysUpWarning(AstroplanWarning):
     """Target is circumpolar"""
     pass
 
-class TargetNeverUpWarning(AstropyWarning):
+class TargetNeverUpWarning(AstroplanWarning):
     """Target never rises above horizon"""
     pass
 
-class OldEarthOrientationDataWarning(AstropyWarning):
+class OldEarthOrientationDataWarning(AstroplanWarning):
     """Using old Earth rotation data from IERS"""
     pass
 
-class PlotWarning(AstropyWarning):
+class PlotWarning(AstroplanWarning):
     """Warnings dealing with the plotting aspects of astroplan"""
     pass
 

--- a/astroplan/exceptions.py
+++ b/astroplan/exceptions.py
@@ -5,7 +5,8 @@ from __future__ import (absolute_import, division, print_function,
 from astropy.utils.exceptions import AstropyWarning
 
 __all__ = ["TargetAlwaysUpWarning", "TargetNeverUpWarning",
-           "OldEarthOrientationDataWarning"]
+           "OldEarthOrientationDataWarning", "PlotWarning",
+           "PlotBelowHorizonWarning"]
 
 class TargetAlwaysUpWarning(AstropyWarning):
     """Target is circumpolar"""
@@ -17,4 +18,12 @@ class TargetNeverUpWarning(AstropyWarning):
 
 class OldEarthOrientationDataWarning(AstropyWarning):
     """Using old Earth rotation data from IERS"""
+    pass
+
+class PlotWarning(AstropyWarning):
+    """Warnings dealing with the plotting aspects of astroplan"""
+    pass
+
+class PlotBelowHorizonWarning(PlotWarning):
+    """Warning for when something is hidden on a plot because it's below the horizon"""
     pass

--- a/astroplan/plots/sky.py
+++ b/astroplan/plots/sky.py
@@ -7,6 +7,8 @@ import astropy.units as u
 from astropy.time import Time
 import warnings
 
+from ..exceptions import PlotBelowHorizonWarning
+
 __all__ = ['plot_sky']
 
 
@@ -126,10 +128,10 @@ def plot_sky(target, observer, time, ax=None, style_kwargs=None,
     az_plot = None
     for alt in range(0, len(altitude)):
         if altitude[alt] > 91.0:
-            msg = 'Warning: Target "{0}" is below the horizon at time: {1}'
-            warnings.warn(
-                msg.format(target_name if target_name else 'Unknown Name',
-                           time[alt]))
+            msg = 'Target "{0}" is below the horizon at time: {1}'
+            msg = msg.format(target_name if target_name else 'Unknown Name',
+                             time[alt])
+            warnings.warn(msg, PlotBelowHorizonWarning)
         else:
             if az_plot is None:
                 az_plot = np.array([azimuth[alt]])

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -7,6 +7,8 @@ import astropy.units as u
 from astropy.time import Time
 import warnings
 
+from ..exceptions import PlotWarning
+
 __all__ = ['plot_airmass', 'plot_parallactic']
 
 
@@ -81,7 +83,9 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None):
     if time.isscalar:
         time = time + np.linspace(-12, 12, 100)*u.hour
     elif len(time) == 1:
-        warnings.warn('You used a Time array of length 1.  Use a scalar or a list with length > 1.')
+        warnings.warn('You used a Time array of length 1.  You probably meant '
+                      'to use a scalar. (Or maybe a list with length > 1?).',
+                      PlotWarning)
 
     # Calculate airmass
     airmass = observer.altaz(time, target).secz
@@ -180,7 +184,9 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None):
     if time.isscalar:
         time = time + np.linspace(-12, 12, 100)*u.hour
     elif len(time) == 1:
-        warnings.warn('You used a Time array of length 1.  Use a scalar or a list with length > 1.')
+        warnings.warn('You used a Time array of length 1.  You probably meant '
+                      'to use a scalar. (Or maybe a list with length > 1?).',
+                      PlotWarning)
 
     # Calculate parallactic angle.
     p_angle = observer.parallactic_angle(time, target)


### PR DESCRIPTION
This adjusts a few areas of code so that astroplan consistently uses customized warning classes.  This is useful because it makes it easy to have fine-grained control over the warnings filter so that users can easily hide warnings that they actually expect to see.

It also adjusts the existing warnings to descend from a base `AstroplanWarning`.  Yet another layer that makes warnings control easier.