### PR TITLE
Fix 76

### DIFF
--- a/astroplan/conftest.py
+++ b/astroplan/conftest.py
@@ -1,7 +1,14 @@
-# this contains imports plugins that configure py.test for astropy tests.
-# by importing them here in conftest.py they are discoverable by py.test
-# no matter how it is invoked within the source tree.
+"""
+This file contains functions that configure py.test like astropy but with
+additions for astroplan.  Py.test looks for specially-named functions
+(like  ``pytest_configure``) and uses those to configure itself.
 
+Here, we want to keep the behavior of astropy while *adding* more for astroplan.
+To do that, in the functions below, we first invoke the functions from astropy,
+and then after that do things specific to astroplan.  But we also want astropy
+functionality for any functions we have *not* overriden, so that's why the
+``import *`` happens at the top.
+"""
 from astropy.tests.pytest_plugins import *
 
 # also save a copy of the astropy hooks so we can use them below when overriding
@@ -46,6 +53,12 @@ def pytest_configure(config):
             config.option.mpl_baseline_path = 'astroplan/plots/tests/baseline_images'
 
 def pytest_runtest_setup(item):
+    """
+    This overrides the tests so that if they are marked ``remote_data`` they get
+    run without any mocking of functions, but if they are not, then the mocking
+    happens.  This means that functionality that uses mock data should have both
+    a ``remote_data`` test *and* a separate one that is not ``remote_data``.
+    """
     if hasattr(astropy_pytest_plugins, 'pytest_runtest_setup'):
         # sure ought to be true right now, but always possible it will change in
         # future versions of astropy

--- a/astroplan/conftest.py
+++ b/astroplan/conftest.py
@@ -7,6 +7,10 @@ from astropy.tests.pytest_plugins import *
 # also save a copy of the astropy hooks so we can use them below when overriding
 from astropy.tests import pytest_plugins as astropy_pytest_plugins
 
+import warnings
+from .utils import _mock_remote_data, _unmock_remote_data
+from .exceptions import OldEarthOrientationDataWarning
+
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions
 enable_deprecations_as_exceptions()
@@ -26,6 +30,9 @@ def pytest_configure(config):
         # sure ought to be true right now, but always possible it will change in
         # future versions of astropy
         astropy_pytest_plugins.pytest_configure(config)
+
+    warnings.simplefilter('always', category=OldEarthOrientationDataWarning)
+
     try:
         import matplotlib
         import nose  # needed for the matplotlib testing tools
@@ -38,8 +45,6 @@ def pytest_configure(config):
             config.option.mpl_baseline_path = 'astroplan/plots/tests/baseline_images'
 
 def pytest_runtest_setup(item):
-    from .utils import _mock_remote_data, _unmock_remote_data
-
     if hasattr(astropy_pytest_plugins, 'pytest_runtest_setup'):
         # sure ought to be true right now, but always possible it will change in
         # future versions of astropy

--- a/astroplan/conftest.py
+++ b/astroplan/conftest.py
@@ -36,22 +36,21 @@ def pytest_runtest_setup(item):
     # Make appropriate substitutions to mock internet querying methods
     # within the tests
     if item.get_marker('remote_data'):
-        1/0
+        # a no-op if the last one was remote-data
+        _unmock_remote_data()
     else:
-        2/0
-    _mock_remote_data()
-
-def pytest_runtest_teardown(item, nextitem):
-    #
-    _unmock_remote_data()
+        # a no-op if the last one was not remote-data
+        _mock_remote_data()
 
 
 def _mock_remote_data():
     # Mock FixedTarget.from_name class method for tests without remote data
     from .target import FixedTarget
 
-    FixedTarget._real_from_name = FixedTarget.from_name
-    FixedTarget.from_name = FixedTarget._from_name_mock
+    if not hasattr(FixedTarget, '_real_from_name'):
+        FixedTarget._real_from_name = FixedTarget.from_name
+        FixedTarget.from_name = FixedTarget._from_name_mock
+    #otherwise already mocked
 
 def _unmock_remote_data():
     # undo _mock_remote_data

--- a/astroplan/conftest.py
+++ b/astroplan/conftest.py
@@ -9,7 +9,7 @@ from astropy.tests import pytest_plugins as astropy_pytest_plugins
 
 import warnings
 from .utils import _mock_remote_data, _unmock_remote_data
-from .exceptions import OldEarthOrientationDataWarning
+from .exceptions import AstroplanWarning
 
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions
@@ -31,7 +31,8 @@ def pytest_configure(config):
         # future versions of astropy
         astropy_pytest_plugins.pytest_configure(config)
 
-    warnings.simplefilter('always', category=OldEarthOrientationDataWarning)
+    #make sure astroplan warnings always appear so we can test when they show up
+    warnings.simplefilter('always', category=AstroplanWarning)
 
     try:
         import matplotlib

--- a/astroplan/conftest.py
+++ b/astroplan/conftest.py
@@ -4,6 +4,9 @@
 
 from astropy.tests.pytest_plugins import *
 
+# also save a copy of the astropy hooks so we can use them below when overriding
+from astropy.tests import pytest_plugins as astropy_pytest_plugins
+
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions
 enable_deprecations_as_exceptions()
@@ -18,9 +21,11 @@ except NameError:  # needed to support Astropy < 1.0
     pass
 
 
-
-
 def pytest_configure(config):
+    if hasattr(astropy_pytest_plugins, 'pytest_configure'):
+        # sure ought to be true right now, but always possible it will change in
+        # future versions of astropy
+        astropy_pytest_plugins.pytest_configure(config)
     try:
         import matplotlib
         import nose  # needed for the matplotlib testing tools
@@ -33,6 +38,13 @@ def pytest_configure(config):
             config.option.mpl_baseline_path = 'astroplan/plots/tests/baseline_images'
 
 def pytest_runtest_setup(item):
+    from .utils import _mock_remote_data, _unmock_remote_data
+
+    if hasattr(astropy_pytest_plugins, 'pytest_runtest_setup'):
+        # sure ought to be true right now, but always possible it will change in
+        # future versions of astropy
+        astropy_pytest_plugins.pytest_runtest_setup(item)
+
     # Make appropriate substitutions to mock internet querying methods
     # within the tests
     if item.get_marker('remote_data'):
@@ -41,22 +53,3 @@ def pytest_runtest_setup(item):
     else:
         # a no-op if the last one was not remote-data
         _mock_remote_data()
-
-
-def _mock_remote_data():
-    # Mock FixedTarget.from_name class method for tests without remote data
-    from .target import FixedTarget
-
-    if not hasattr(FixedTarget, '_real_from_name'):
-        FixedTarget._real_from_name = FixedTarget.from_name
-        FixedTarget.from_name = FixedTarget._from_name_mock
-    #otherwise already mocked
-
-def _unmock_remote_data():
-    # undo _mock_remote_data
-    from .target import FixedTarget
-
-    if hasattr(FixedTarget, '_real_from_name'):
-        FixedTarget.from_name = FixedTarget._real_from_name
-        del FixedTarget._real_from_name
-    #otherwise assume it's already correct

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -148,9 +148,10 @@ class FixedTarget(Target):
         return '<{} "{}" at {}>'.format(class_name, self.name, fmt_coord)
 
     @classmethod
-    def _fixed_target_from_name_mock(cls, query_name, name=None):
+    def _from_name_mock(cls, query_name, name=None):
         """
-        Mock method to replace `FixedTarget.from_name` in tests.
+        Mock method to replace `FixedTarget.from_name` in tests without
+        internet connection.
         """
         stars = {
             "rigel": {"ra": 78.63446707*u.deg, "dec": -8.20163837*u.deg},

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -141,3 +141,27 @@ def time_grid_from_range(time_range, time_resolution=0.5*u.hour):
     """
     return Time(np.arange(time_range[0].jd, time_range[1].jd,
                           time_resolution.to(u.day).value), format='jd')
+
+def _mock_remote_data():
+    """
+    Mock FixedTarget.from_name class method for tests without remote data
+
+    Actually called in conftest.py
+    """
+    from .target import FixedTarget
+
+    if not hasattr(FixedTarget, '_real_from_name'):
+        FixedTarget._real_from_name = FixedTarget.from_name
+        FixedTarget.from_name = FixedTarget._from_name_mock
+    #otherwise already mocked
+
+def _unmock_remote_data():
+    """
+    undo _mock_remote_data
+    """
+    from .target import FixedTarget
+
+    if hasattr(FixedTarget, '_real_from_name'):
+        FixedTarget.from_name = FixedTarget._real_from_name
+        del FixedTarget._real_from_name
+    #otherwise assume it's already correct

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -28,10 +28,6 @@ IERS_A_WARNING = ("For best precision (on the order of arcseconds), you must "
 
 BACKUP_Time_get_delta_ut1_utc = Time._get_delta_ut1_utc
 
-def _mock_remote_data():
-    # Mock FixedTarget.from_name class method for tests without remote data
-    from astroplan.target import FixedTarget
-    FixedTarget.from_name = FixedTarget._fixed_target_from_name_mock
 
 def _low_precision_utc_to_ut1(self, jd1, jd2):
     """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,9 +176,12 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # otherwise, readthedocs.org uses their theme by default, so no need to specify it
 
 # Make appropriate substitutions to mock internet querying methods
-# within the tests
-from astroplan.utils import _mock_remote_data
-_mock_remote_data()
+# within the tests.
+# Currently this is not needed because of the content of the tests, but we leave
+# it here in case it's needed again in the future.  BUT beware of:
+# https://github.com/astropy/astroplan/issues/96
+#from astroplan.utils import _mock_remote_data
+#_mock_remote_data()
 
 # Add additional Sphinx extensions:
 extensions += ['matplotlib.sphinxext.plot_directive']

--- a/docs/tutorials/summer_triangle.rst
+++ b/docs/tutorials/summer_triangle.rst
@@ -193,15 +193,15 @@ can plot it over the course of the night (for more on plotting see :doc:`plots`)
 
 .. code-block:: python
 
-    >>> from astroplan.plots import plot_airmass
-    >>> import matplotlib.pyplot as plt
+    >>> from astroplan.plots import plot_airmass # doctest: +SKIP
+    >>> import matplotlib.pyplot as plt # doctest: +SKIP
 
     >>> plot_airmass(altair, subaru, time) # doctest: +SKIP
-    >>> plot_airmass(vega, subaru, time)
-    >>> plot_airmass(deneb, subaru, time)
+    >>> plot_airmass(vega, subaru, time) # doctest: +SKIP
+    >>> plot_airmass(deneb, subaru, time)  # doctest: +SKIP
 
-    >>> plt.legend(loc=1, bbox_to_anchor=(1, 1))
-    >>> plt.show()
+    >>> plt.legend(loc=1, bbox_to_anchor=(1, 1)) # doctest: +SKIP
+    >>> plt.show() # doctest: +SKIP
 
 .. plot::
 
@@ -262,13 +262,13 @@ use the ``AltAz`` frame:
 
 .. code-block:: python
 
-    >>> subaru.altaz(time, altair).secz
+    >>> subaru.altaz(time, altair).secz # doctest: +SKIP
     <Quantity 1.0302347952130682>
 
-    >>> subaru.altaz(time, vega).secz
+    >>> subaru.altaz(time, vega).secz # doctest: +SKIP
     <Quantity 1.0690421636016616>
 
-    >>> subaru.altaz(time, deneb).secz
+    >>> subaru.altaz(time, deneb).secz # doctest: +SKIP
     <Quantity 1.167753811648361>
 
 Behind the scenes here, ``subaru.altaz(time, altair)`` is actually creating an
@@ -285,15 +285,15 @@ customizing plots and the like):
 
 .. code-block:: python
 
-    >>> import matplotlib.pyplot as plt
-    >>> from astroplan.plots import plot_parallactic
+    >>> import matplotlib.pyplot as plt # doctest: +SKIP
+    >>> from astroplan.plots import plot_parallactic # doctest: +SKIP
 
-    >>> plot_parallactic(altair, subaru, time)
-    >>> plot_parallactic(vega, subaru, time)
-    >>> plot_parallactic(deneb, subaru, time)
+    >>> plot_parallactic(altair, subaru, time) # doctest: +SKIP
+    >>> plot_parallactic(vega, subaru, time) # doctest: +SKIP
+    >>> plot_parallactic(deneb, subaru, time) # doctest: +SKIP
 
-    >>> plt.legend(loc=2)
-    >>> plt.show()
+    >>> plt.legend(loc=2) # doctest: +SKIP
+    >>> plt.show() # doctest: +SKIP
 
 .. plot::
 
@@ -342,13 +342,13 @@ We can also calculate the parallactic angle directly:
 
 .. code-block:: python
 
-    >>> subaru.parallactic_angle(time, altair)
+    >>> subaru.parallactic_angle(time, altair) # doctest: +SKIP
     <Angle -0.6404957821112053 rad>
 
-    >>> subaru.parallactic_angle(time, vega)
+    >>> subaru.parallactic_angle(time, vega) # doctest: +SKIP
     <Angle -0.46542183982024 rad>
 
-    >>> subaru.parallactic_angle(time, deneb)
+    >>> subaru.parallactic_angle(time, deneb) # doctest: +SKIP
     <Angle 0.7297067855978494 rad>
 
 The `~astropy.coordinates.Angle` objects resulting from the calls to
@@ -383,10 +383,10 @@ We could also look at the Moon's alt/az coordinates:
 
 .. code-block:: python
 
-    >>> subaru.moon_altaz(time).alt
+    >>> subaru.moon_altaz(time).alt # doctest: +SKIP
     <Latitude -45.08860929634166 deg>
 
-    >>> subaru.moon_altaz(time).az
+    >>> subaru.moon_altaz(time).az # doctest: +SKIP
     <Longitude 34.605498354422686 deg>
 
 It looks like the Moon is well below the horizon at the time we picked before,
@@ -397,7 +397,7 @@ targets will be visible (again--as defined at the beginning of this tutorial):
 
     >>> visible_time = start + (end - start)*np.linspace(0, 1, 20)
 
-    >>> subaru.moon_altaz(visible_time).alt
+    >>> subaru.moon_altaz(visible_time).alt # doctest: +SKIP
     <Latitude [-25.21127325,-30.68088873,-35.82145644,-40.53415037,
                -44.68898859,-48.12296182,-50.64971858,-52.08946099,
                -52.31849772,-51.31548444,-49.17038499,-46.04862654,
@@ -428,24 +428,24 @@ targets lay in the sky:
 .. code-block:: python
 
     >>> from astroplan.plots import plot_sky
-    >>> import matplotlib.pyplot as plt
+    >>> import matplotlib.pyplot as plt  # doctest: +SKIP
 
     >>> altair_style = {'color': 'r'}
     >>> deneb_style = {'color': 'g'}
 
-    >>> plot_sky(altair, subaru, start, style_kwargs=altair_style)
-    >>> plot_sky(vega, subaru, start)
-    >>> plot_sky(deneb, subaru, start, style_kwargs=deneb_style)
+    >>> plot_sky(altair, subaru, start, style_kwargs=altair_style)  # doctest: +SKIP
+    >>> plot_sky(vega, subaru, start)  # doctest: +SKIP
+    >>> plot_sky(deneb, subaru, start, style_kwargs=deneb_style)  # doctest: +SKIP
 
-    >>> plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
-    >>> plt.show()
+    >>> plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))  # doctest: +SKIP
+    >>> plt.show()  # doctest: +SKIP
 
-    >>> plot_sky(altair, subaru, end, style_kwargs=altair_style)
-    >>> plot_sky(vega, subaru, end)
-    >>> plot_sky(deneb, subaru, end, style_kwargs=deneb_style)
+    >>> plot_sky(altair, subaru, end, style_kwargs=altair_style)  # doctest: +SKIP
+    >>> plot_sky(vega, subaru, end)  # doctest: +SKIP
+    >>> plot_sky(deneb, subaru, end, style_kwargs=deneb_style)  # doctest: +SKIP
 
-    >>> plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
-    >>> plt.show()
+    >>> plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))  # doctest: +SKIP
+    >>> plt.show()  # doctest: +SKIP
 
 .. plot::
 
@@ -517,12 +517,12 @@ We can also show how our targets move over time during the night in question::
 
     >>> time_window = start + (end - start) * np.linspace(0, 1, 10)
 
-    >>> plot_sky(altair, subaru, time_window, style_kwargs=altair_style)
-    >>> plot_sky(vega, subaru, time_window)
-    >>> plot_sky(deneb, subaru, time_window, style_kwargs=deneb_style)
+    >>> plot_sky(altair, subaru, time_window, style_kwargs=altair_style)  # doctest: +SKIP
+    >>> plot_sky(vega, subaru, time_window)  # doctest: +SKIP
+    >>> plot_sky(deneb, subaru, time_window, style_kwargs=deneb_style)  # doctest: +SKIP
 
-    >>> plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))
-    >>> plt.show()
+    >>> plt.legend(loc='center left', bbox_to_anchor=(1.25, 0.5))  # doctest: +SKIP
+    >>> plt.show()  # doctest: +SKIP
 
 .. plot::
 


### PR DESCRIPTION
This fixes #76 by adjusting the `from_name` mocking to turn on or off depending on whether a test is ``remote-data`` or not. I can confirm via the method of unplugging my ethernet cord that after this the remote_data tests fail if the internet is off.