### PR TITLE
Simplify pytest remote data mock setup

### DIFF
--- a/astroplan/conftest.py
+++ b/astroplan/conftest.py
@@ -18,18 +18,17 @@ import warnings
 from .utils import _mock_remote_data, _unmock_remote_data
 from .exceptions import AstroplanWarning
 
-## Uncomment the following line to treat all DeprecationWarnings as
-## exceptions
+# Comment out this line to avoid deprecation warnings being raised as exceptions
 enable_deprecations_as_exceptions()
 
-## Uncomment and customize the following lines to add/remove entries
-## from the list of packages for which version numbers are displayed
-## when running the tests
-try:
-    PYTEST_HEADER_MODULES['pyephem'] = 'pyephem'
-    del PYTEST_HEADER_MODULES['h5py']
-except NameError:  # needed to support Astropy < 1.0
-    pass
+# Define list of packages for which to display version numbers in the test log
+PYTEST_HEADER_MODULES['astropy'] = 'astropy'
+PYTEST_HEADER_MODULES['pytz'] = 'pytz'
+PYTEST_HEADER_MODULES['pyephem'] = 'pyephem'
+PYTEST_HEADER_MODULES['matplotlib'] = 'matplotlib'
+PYTEST_HEADER_MODULES['nose'] = 'nose'
+PYTEST_HEADER_MODULES['pytest-mpl'] = 'pytest-mpl'
+del PYTEST_HEADER_MODULES['h5py']
 
 
 def pytest_configure(config):
@@ -38,9 +37,11 @@ def pytest_configure(config):
         # future versions of astropy
         astropy_pytest_plugins.pytest_configure(config)
 
-    #make sure astroplan warnings always appear so we can test when they show up
+    # make sure astroplan warnings always appear so we can test when they show up
     warnings.simplefilter('always', category=AstroplanWarning)
 
+    # activate image comparison tests only if the dependencies needed are installed:
+    # matplotlib, nose, pytest-mpl
     try:
         import matplotlib
         import nose  # needed for the matplotlib testing tools
@@ -52,23 +53,6 @@ def pytest_configure(config):
             config.option.mpl = True
             config.option.mpl_baseline_path = 'astroplan/plots/tests/baseline_images'
 
-def pytest_runtest_setup(item):
-    """
-    This overrides the tests so that if they are marked ``remote_data`` they get
-    run without any mocking of functions, but if they are not, then the mocking
-    happens.  This means that functionality that uses mock data should have both
-    a ``remote_data`` test *and* a separate one that is not ``remote_data``.
-    """
-    if hasattr(astropy_pytest_plugins, 'pytest_runtest_setup'):
-        # sure ought to be true right now, but always possible it will change in
-        # future versions of astropy
-        astropy_pytest_plugins.pytest_runtest_setup(item)
-
-    # Make appropriate substitutions to mock internet querying methods
-    # within the tests
-    if item.get_marker('remote_data'):
-        # a no-op if the last one was remote-data
-        _unmock_remote_data()
-    else:
-        # a no-op if the last one was not remote-data
+    # Activate remote data mocking if the `--remote-data` option isn't used:
+    if not config.getoption('remote_data'):
         _mock_remote_data()

--- a/astroplan/tests/test_target.py
+++ b/astroplan/tests/test_target.py
@@ -4,13 +4,12 @@ from __future__ import (absolute_import, division, print_function,
 
 # Third-party
 import astropy.units as u
-from astropy.tests.helper import remote_data
 from astropy.coordinates import SkyCoord
 
 # Package
 from ..target import FixedTarget
 
-@remote_data
+
 def test_FixedTarget_from_name():
     """
     Check that resolving target names with the `SkyCoord.from_name` constructor
@@ -25,6 +24,7 @@ def test_FixedTarget_from_name():
 
     # Make sure separation is small
     assert polaris_from_name.coord.separation(polaris_from_SIMBAD) < 1*u.arcsec
+
 
 def test_FixedTarget_ra_dec():
     """

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -147,26 +147,43 @@ def time_grid_from_range(time_range, time_resolution=0.5*u.hour):
     return Time(np.arange(time_range[0].jd, time_range[1].jd,
                           time_resolution.to(u.day).value), format='jd')
 
+
 def _mock_remote_data():
     """
-    Mock FixedTarget.from_name class method for tests without remote data
+    Apply mocks (i.e. monkey-patches) to avoid the need for internet access
+    for certain things.
 
-    Actually called in conftest.py
+    This is currently called in `astroplan/conftest.py` when the tests are run
+    and the `--remote-data` option isn't used.
+
+    The way this setup works is that for functionality that usuasally requires
+    internet access, but has mocks in place, it is possible to write the test
+    without adding a `@remote_data` decorator, and `py.test` will do the right
+    thing when running the tests:
+
+    1. Access the internet and use the normal code if `--remote-data` is used
+    2. Not access the internet and use the mock code if `--remote-data` is not used
+
+    Both of these cases are tested on travis-ci.
+
+    Currently only `FixedTarget.from_name` is mocked.
     """
     from .target import FixedTarget
 
     if not hasattr(FixedTarget, '_real_from_name'):
         FixedTarget._real_from_name = FixedTarget.from_name
         FixedTarget.from_name = FixedTarget._from_name_mock
-    #otherwise already mocked
+    # otherwise already mocked
+
 
 def _unmock_remote_data():
     """
     undo _mock_remote_data
+    currently unused
     """
     from .target import FixedTarget
 
     if hasattr(FixedTarget, '_real_from_name'):
         FixedTarget.from_name = FixedTarget._real_from_name
         del FixedTarget._real_from_name
-    #otherwise assume it's already correct
+    # otherwise assume it's already correct


### PR DESCRIPTION
This is an attempt to simplify the pytest remote data mock setup that was introduced in #98.

Please see https://github.com/astropy/astroplan/pull/98#issuecomment-137570869 and https://github.com/astropy/astroplan/pull/98#issuecomment-137680812 as well as the 
docstring of  `_mock_remote_data` in this PR where I try to explain how it works and why it's an improvement.