### PR TITLE
test_image_example fails when run via astroplan.test()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,14 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.4 SETUP_CMD='test -V'
 
+        # Try running tests from an installed version via the `astroplan.test()` function
+        # Because of the way this travis config file is written this is a bit cryptic.
+        # - $MAIN_CMD is used to trigger this case in the install section below
+        # - $SETUP_CMD is used to communicate which dependencies should be installed
+        - os: linux
+          env: PYTHON_VERSION=3.4 $MAIN_CMD='test installed' SETUP_CMD='test --remote-data -V' OPTIONAL_DEPS=true
+
+
         # Now try with all optional dependencies on 2.7 and an appropriate 3.x
         # build (with latest numpy). We also note the code coverage on Python
         # 2.7.
@@ -100,7 +108,17 @@ install:
     - source .continuous-integration/travis/setup_environment_$TRAVIS_OS_NAME.sh
 
 script:
-    - $MAIN_CMD $SETUP_CMD
+    - if [[ $MAIN_CMD == 'python setup.py' ]]; then
+        $MAIN_CMD $SETUP_CMD;
+      fi
+
+    # Check if install and testing via `astroplan.test()` works
+    - if [[ $MAIN_CMD == 'test installed' ]]; then
+        python setup.py install;
+        cd /tmp;
+        python -c 'import astroplan; import sys; sys.exit(astroplan.test())'';
+      fi
+
 
 after_success:
     - if [[ $SETUP_CMD == 'test --remote-data -V --coverage' ]]; then

--- a/astroplan/conftest.py
+++ b/astroplan/conftest.py
@@ -49,8 +49,11 @@ def pytest_configure(config):
         HAS_MATPLOTLIB_AND_NOSE = False
 
     if HAS_MATPLOTLIB_AND_NOSE and config.pluginmanager.hasplugin('mpl'):
-            config.option.mpl = True
-            config.option.mpl_baseline_path = 'astroplan/plots/tests/baseline_images'
+        pass
+        # TODO: turn image comparison tests back on once this issue is figured out:
+        # https://github.com/astropy/astroplan/pull/104#issuecomment-137734007
+        # config.option.mpl = True
+        # config.option.mpl_baseline_path = 'astroplan/plots/tests/baseline_images'
 
 def pytest_runtest_setup(item):
     """


### PR DESCRIPTION
I noticed that `test_image_example` fails when run via `astroplan.test()`:
https://gist.github.com/cdeil/f5dc761311130ff1062a#file-gistfile1-txt-L1

I'll add a travis-ci build here that tests for this case and then will try to fix it.
(My guess is that the issue is that the test image filename needs to be declared in the test decorator, so that it's installed in the tmp test folder by pytest-mpl before running the test?)