### PR TITLE
Adding anaconda installation example

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,9 +29,13 @@ package, such as the `Anaconda Python Distribution
 Installation
 ============
 
-You can install the stable version of astroplan with::
+You can install the stable version of astroplan from PyPI with::
 
     pip install astroplan
+
+or from anaconda::
+
+    conda install -c https://conda.binstar.org/astropy astroplan
 
 Alternatively, you can install the latest developer version of astroplan by
 cloning the git repository::


### PR DESCRIPTION
Now that `astroplan` appears in the `astropy` binstar repo via astropy/conda-builder-affiliated#54 (see [here](https://binstar.org/astropy/astroplan)), conda users can install astroplan with: 
```
conda install -c https://conda.binstar.org/astropy astroplan
```
This PR adds that line to the installation docs. cc @cdeil @eteq 