### PR TITLE
Adding Manastash Ridge Observatory to the observatory database

### DIFF
--- a/astroplan/data/observatories.json
+++ b/astroplan/data/observatories.json
@@ -367,5 +367,18 @@
         "aliases": [
             "Observatorio Astronomico Nacional, San Pedro Martir"
         ]
+    },
+    "mro": {
+        "aliases": [
+            "Manastash Ridge Observatory"
+        ],
+        "elevation": 1198,
+        "elevation_unit": "meter",
+        "latitude": 46.9528,
+        "latitude_unit": "degree",
+        "longitude": -120.7278,
+        "longitude_unit": "degree",
+        "name": "mro",
+        "source": "MRO website"
     }
 }


### PR DESCRIPTION
Observatory info source: [MRO website](http://www.astro.washington.edu/users/laws/MRO/home.page/History.Basics.html).

This observatory is a fairly minor one, but one used by UW undergraduates who will be taught to use `astroplan` in their observing class.