### PR TITLE
FAQ note on adding an observatory

### DIFF
--- a/astroplan/sites.py
+++ b/astroplan/sites.py
@@ -21,7 +21,7 @@ from astropy.utils.data import get_pkg_data_contents
 from astropy.coordinates import EarthLocation
 import astropy.units as u
 
-__all__ = ['get_site', 'get_site_names', 'add_site']
+__all__ = ['get_site', 'get_site_names', 'add_site', 'new_site_info_to_json']
 
 # Observatory database and list of names:
 _site_db = None

--- a/docs/faq/addobservatory.rst
+++ b/docs/faq/addobservatory.rst
@@ -1,0 +1,23 @@
+.. doctest-skip-all
+
+.. _addobservatory:
+
+********************************************************
+How can I add observatories to the observatory database?
+********************************************************
+
+`astroplan` has a convenience methods for creating an
+`~astropy.coordinates.EarthLocation` object at the location of an observatory
+– see `~astroplan.get_site`, `~astroplan.get_site_names` and
+`~astroplan.add_site` for more on what you can do with the observatory
+database).
+
+The observatory database is stored as a JSON file in the `astroplan/data`
+directory. If you would like to add an observatory to the observatory database
+for distribution in the `astroplan` source code, use the
+`~astroplan.new_site_info_to_json` function to output the observatory's
+information into a string with the proper JSON format. Then you can copy and
+paste that JSON string with the new observatory's information into the
+astroplan/data/observatories.json` file and submit a
+`pull request on GitHub <https://github.com/astropy/astroplan/pulls>`_ to add
+that observatory to the source code.

--- a/docs/faq/index.rst
+++ b/docs/faq/index.rst
@@ -15,3 +15,4 @@ new issue.
    iers
    precision
    contribute
+   addobservatory


### PR DESCRIPTION
Today I got asked by a user if it's OK to add observatories to the database, and I realized there was no way users would naturally find the convenience method I wrote for this purpose. 

In this PR I've added a quick note in the FAQ on how to add an observatory to the observatory database (simply directing the user to the [`new_site_info_to_json`](https://github.com/astropy/astroplan/blob/master/astroplan/sites.py#L135) method). 

cc @eteq / @cdeil 