### PR TITLE
Fix sphinx_rtd install on travis-ci

### DIFF
--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -53,9 +53,9 @@ fi
 # build_sphinx needs sphinx as well as matplotlib and wcsaxes (for plot_directive). 
 if [[ $SETUP_CMD == build_sphinx* ]]
 then
-  $CONDA_INSTALL Sphinx Pygments matplotlib
-  pip install wcsaxes
+  $CONDA_INSTALL matplotlib
   pip install sphinx_rtd_theme
+  pip install wcsaxes
 fi
 
 # COVERAGE DEPENDENCIES

--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -53,7 +53,7 @@ fi
 # build_sphinx needs sphinx as well as matplotlib and wcsaxes (for plot_directive). 
 if [[ $SETUP_CMD == build_sphinx* ]]
 then
-  $CONDA_INSTALL matplotlib sphinx_rtd_theme
+  $CONDA_INSTALL matplotlib Sphinx Pygments sphinx_rtd_theme
   pip install wcsaxes
 fi
 

--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -53,8 +53,7 @@ fi
 # build_sphinx needs sphinx as well as matplotlib and wcsaxes (for plot_directive). 
 if [[ $SETUP_CMD == build_sphinx* ]]
 then
-  $CONDA_INSTALL matplotlib
-  pip install sphinx_rtd_theme
+  $CONDA_INSTALL matplotlib sphinx_rtd_theme
   pip install wcsaxes
 fi
 


### PR DESCRIPTION
After merging #116 the issue came up that sphinx_rtd wasn't installed, but needed for the Sphinx build (don't know why this appeared only now)?
https://travis-ci.org/astropy/astroplan/jobs/82734139#L643

So I added a `pip install sphinx_rtd` to `setup_dependencies_common.sh`, but now I'm getting this error:
https://travis-ci.org/astropy/astroplan/jobs/82742624#L613

It might be a pip or conda issue or packaging issue with one of the `sphinx_rtd` dependencies, I don't know. This seems releated: https://github.com/pypa/pip/issues/2751#issuecomment-144073543

So here I'll try installing this package differently, e.g. using pip instead of conda to install sphinx.
@astrofrog Maybe you've seen this before or have an idea what to do?