### PR TITLE
Adding EclipsingFixedTarget, PrimaryEclipseConstraint

### DIFF
--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -22,13 +22,13 @@ import numpy as np
 # Package
 from .moon import get_moon, moon_illumination
 from .utils import time_grid_from_range
-from .target import FixedTarget
+from .target import FixedTarget, EclipsingFixedTarget
 
 __all__ = ["AltitudeConstraint", "AirmassConstraint", "AtNightConstraint",
            "is_observable", "is_always_observable", "time_grid_from_range",
            "SunSeparationConstraint", "MoonSeparationConstraint",
            "MoonIlluminationConstraint", "LocalTimeConstraint", "Constraint",
-           "observability_table"]
+           "observability_table", "PrimaryEclipseConstraint"]
 
 
 def _get_altaz(times, observer, targets,
@@ -468,6 +468,34 @@ class LocalTimeConstraint(Constraint):
 
         return mask
 
+class PrimaryEclipseConstraint(Constraint):
+    """
+    Constrain observations to times during primary eclipses of
+    `~astroplan.EclipsingFixedTarget` objects in the list of targets.
+    """
+    def __init__(self, buffer_duration=None):
+        """
+        Parameters
+        ----------
+        buffer_duration : `~astropy.units.Quantity`
+            Extra time before and after the event to require that the target
+            is observable. Defaults to zero.
+        """
+        if buffer_duration is None:
+            buffer_duration = 0*u.min
+        self.buffer_duration = buffer_duration
+
+    def compute_constraint(self, times, observer, targets):
+        mask = np.zeros((len(times), len(targets)), dtype=bool)
+
+        for i, target in enumerate(targets):
+            if isinstance(target, EclipsingFixedTarget):
+                phase = abs(times - target.epoch).to(u.day) % target.period
+                mask[:, i] |= ((phase <= 0.5*(target.duration +
+                                              self.buffer_duration)) |
+                               (phase >= target.period - 0.5*(target.duration +
+                                                              self.buffer_duration)))
+        return mask
 
 def is_always_observable(constraints, observer, targets, times=None,
                          time_range=None, time_grid_resolution=0.5*u.hour):

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -210,6 +210,26 @@ class EclipsingFixedTarget(FixedTarget):
         self.epoch = epoch
 
     def mid_eclipse_time(self, time, which='nearest'):
+        """
+        Mid-eclipse time.
+
+        Parameters
+        ----------
+        time : `~astropy.time.Time` or other (see below)
+            Time of observations. This will be passed in as the first argument to
+            the `~astropy.time.Time` initializer, so it can be anything that
+            `~astropy.time.Time` will accept (including a `~astropy.time.Time`
+            object).
+
+        which : {'next', 'previous', 'nearest'}
+            Choose which mid-eclipse relative to the present ``time`` would you
+            like to calculate. Default is nearest.
+
+        Returns
+        -------
+        `~astropy.time.Time`
+            Time of mid-eclipse
+        """
         if not isinstance(time, Time):
             time = Time(time)
         phase_at_time = abs(time - self.epoch).to(u.day) % self.period
@@ -225,6 +245,94 @@ class EclipsingFixedTarget(FixedTarget):
                 return next_eclipse
             else:
                 return previous_eclipse
+        else:
+            raise ValueError('"which" kwarg must be "next", "previous" or '
+                             '"nearest".')
+
+    def ingress_time(self, time, which='nearest'):
+        """
+        Ingress time.
+
+        Assumes that the difference between time of ingress and the time of
+        mid-eclipse is equivalent to the difference between the time of egress
+        to the time of egress (i.e. strictly true for circular orbits only).
+
+        Parameters
+        ----------
+        time : `~astropy.time.Time` or other (see below)
+            Time of observations. This will be passed in as the first argument to
+            the `~astropy.time.Time` initializer, so it can be anything that
+            `~astropy.time.Time` will accept (including a `~astropy.time.Time`
+            object).
+
+        which : {'next', 'previous', 'nearest'}
+            Choose which ingress relative to the present ``time`` would you
+            like to calculate. Default is nearest.
+
+        Returns
+        -------
+        `~astropy.time.Time`
+            Time of ingress
+        """
+        if not isinstance(time, Time):
+            time = Time(time)
+        phase_at_time = abs(time - self.epoch).to(u.day) % self.period
+        next_ingress = time + (self.period - phase_at_time) - 0.5*self.duration
+        previous_ingress = time - phase_at_time - 0.5*self.duration
+
+        if which == 'next':
+            return next_ingress
+        elif which == 'previous':
+            return previous_ingress
+        elif which == 'nearest':
+            if abs(next_ingress - time) < abs(previous_ingress - time):
+                return next_ingress
+            else:
+                return previous_ingress
+        else:
+            raise ValueError('"which" kwarg must be "next", "previous" or '
+                             '"nearest".')
+
+    def egress_time(self, time, which='nearest'):
+        """
+        Egress time.
+
+        Assumes that the difference between time of ingress and the time of
+        mid-eclipse is equivalent to the difference between the time of egress
+        to the time of egress (i.e. strictly true for circular orbits only).
+
+        Parameters
+        ----------
+        time : `~astropy.time.Time` or other (see below)
+            Time of observations. This will be passed in as the first argument to
+            the `~astropy.time.Time` initializer, so it can be anything that
+            `~astropy.time.Time` will accept (including a `~astropy.time.Time`
+            object).
+
+        which : {'next', 'previous', 'nearest'}
+            Choose which egress relative to the present ``time`` would you
+            like to calculate. Default is nearest.
+
+        Returns
+        -------
+        `~astropy.time.Time`
+            Time of egress
+        """
+        if not isinstance(time, Time):
+            time = Time(time)
+        phase_at_time = abs(time - self.epoch).to(u.day) % self.period
+        next_egress = time + (self.period - phase_at_time) + 0.5*self.duration
+        previous_egress = time - phase_at_time + 0.5*self.duration
+
+        if which == 'next':
+            return next_egress
+        elif which == 'previous':
+            return previous_egress
+        elif which == 'nearest':
+            if abs(next_egress - time) < abs(previous_egress - time):
+                return next_egress
+            else:
+                return previous_egress
         else:
             raise ValueError('"which" kwarg must be "next", "previous" or '
                              '"nearest".')

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -10,12 +10,12 @@ from astropy.coordinates import SkyCoord, get_sun
 
 from ..moon import get_moon
 from ..observer import Observer
-from ..target import FixedTarget
+from ..target import FixedTarget, EclipsingFixedTarget
 from ..constraints import (AltitudeConstraint, AirmassConstraint, AtNightConstraint,
                            is_observable, is_always_observable, observability_table,
                            time_grid_from_range, SunSeparationConstraint,
                            MoonSeparationConstraint, MoonIlluminationConstraint,
-                           LocalTimeConstraint)
+                           LocalTimeConstraint, PrimaryEclipseConstraint)
 
 try:
     import ephem
@@ -314,3 +314,25 @@ def test_docs_example():
                                   time_range=time_range)
 
     assert all(observability == [False, False, True, False, False, False])
+
+def test_primary_eclipse_constraint():
+    coord = SkyCoord(ra=300.18213945*u.deg, dec=22.71085126*u.deg, frame='icrs')
+    epoch = Time(2454279.436714, format='jd')
+    period = 2.21857567*u.day
+    duration = 0.0760*u.day
+
+    hd189 = EclipsingFixedTarget(coord, name='HD 189733 b', epoch=epoch,
+                                 period=period, duration=duration)
+
+    obs = Observer.at_site("APO")
+    targets = [hd189]
+    time_range1 = Time(['2015-09-30 00:00', '2015-10-01 06:00'])
+    time_range2 = Time(['2015-09-30 00:00', '2015-10-01 02:00'])
+    constraints = PrimaryEclipseConstraint()
+
+    is_in_transit_in_range = is_observable(constraints, obs, targets,
+                                           time_range=time_range1)
+    not_in_transit = is_observable(constraints, obs, targets,
+                                   time_range=time_range2)
+    assert np.any(is_in_transit_in_range)
+    assert not np.any(not_in_transit)

--- a/astroplan/tests/test_target.py
+++ b/astroplan/tests/test_target.py
@@ -53,12 +53,17 @@ def test_eclipsing():
     time = Time('2015-10-02 05:48')
     hd189 = EclipsingFixedTarget(coord, name='HD 189733 b', epoch=epoch,
                                  period=period, duration=duration)
-    next_eclipse = hd189.eclipse_time(Time.now(), which='next')
-    previous_eclipse = hd189.eclipse_time(Time.now(), which='previous')
-    nearest_eclipse = hd189.eclipse_time(Time.now(), which='nearest')
+
+    # Mid-eclipse times
+
+    next_eclipse = hd189.mid_eclipse_time(time, which='next')
+    previous_eclipse = hd189.mid_eclipse_time(time, which='previous')
+    nearest_eclipse = hd189.mid_eclipse_time(time, which='nearest')
 
     # Check answers versus the Czech Astronomical Society's Exoplanet Transit
-    # Database webpage results for T0(HJD)=2453988.80336, Per=2.2185733 d:
+    # Database (http://var2.astro.cz/ETD/predictions.php) results for
+    # T0(HJD)=2453988.80336, Per=2.2185733 d, dur=109.6 min
+    ETD_duration = 109.6*u.min
     ETD_previous_eclipse = Time(2457296.696, format='jd')
     ETD_next_eclipse = Time(2457298.915, format='jd')
     ETD_nearest_eclipse = (ETD_previous_eclipse if
@@ -69,3 +74,37 @@ def test_eclipsing():
     assert abs(next_eclipse - ETD_next_eclipse) < tolerance
     assert abs(previous_eclipse - ETD_previous_eclipse) < tolerance
     assert abs(nearest_eclipse - ETD_nearest_eclipse) < tolerance
+
+    # Ingress times
+
+    next_ingress = hd189.ingress_time(time, which='next')
+    previous_ingress = hd189.ingress_time(time, which='previous')
+    nearest_ingress = hd189.ingress_time(time, which='nearest')
+
+    ETD_next_ingress = ETD_next_eclipse - 0.5*ETD_duration
+    ETD_previous_ingress = ETD_previous_eclipse - 0.5*ETD_duration
+    ETD_nearest_ingress = (ETD_previous_ingress if
+                           abs(ETD_previous_ingress - time) <
+                           abs(ETD_next_ingress - time) else ETD_next_ingress)
+
+    assert abs(next_ingress - ETD_next_ingress) < tolerance
+    assert abs(previous_ingress - ETD_previous_ingress) < tolerance
+    assert abs(nearest_ingress - ETD_nearest_ingress) < tolerance
+
+    # Egress times
+
+    next_egress = hd189.egress_time(time, which='next')
+    previous_egress = hd189.egress_time(time, which='previous')
+    nearest_egress = hd189.egress_time(time, which='nearest')
+
+    ETD_next_egress = ETD_next_eclipse + 0.5*ETD_duration
+    ETD_previous_egress = ETD_previous_eclipse + 0.5*ETD_duration
+    ETD_nearest_egress = (ETD_previous_egress if
+                           abs(ETD_previous_egress - time) <
+                           abs(ETD_next_egress - time) else ETD_next_egress)
+
+    assert abs(next_egress - ETD_next_egress) < tolerance
+    assert abs(previous_egress - ETD_previous_egress) < tolerance
+    assert abs(nearest_egress - ETD_nearest_egress) < tolerance
+
+


### PR DESCRIPTION
In the interest of satisfying the needs of my collaborators and myself, I'm going to start pushing for features like predictions of exoplanet transits and eclipsing binary occultations, beginning with this PR. This is a commit meant to start a discussion, and I anticipate adding more to this PR (like docs!) before it gets merged.

I made a new subclass of `FixedTarget` called `EclipsingFixedTarget` which takes the following additional arguments: `epoch`, `period` and `duration`, which are the most general parameters that I can think of for a periodically eclipsing object. These properties can then be used by methods specific to these targets in other modules (like `constraints`, for example...). There are three methods on the subclass that does a computation, `mid_eclipse_time(time, [which])`, `ingress_time(time, [which])` and `egress_time(time, [which])`, which computes the nearest/next/previous time of mid-eclipse/ingress/egress relative to the input `time`.

I also made a new constraint `PrimaryEclipseConstraint` which cycles through the list of targets passed to e.g. `is_observable` or `is_always_observable` and computes when `EclipsingFixedTarget`s are eclipsing.

Opinions on implementation and approach? cc @eteq @cdeil @adrn

[FYI @adleorocks @kolbylyn – this PR will replace my old transit/eclipse predicting code soon enough!]
