### PR TITLE
Plot fixes

### DIFF
--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -113,7 +113,7 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None):
 
     # Set labels.
     ax.set_ylabel("Airmass")
-    ax.set_xlabel("Time")
+    ax.set_xlabel("Time - {0} [UTC]".format(min(time).datetime.date()))
 
     # Redraw figure for interactive sessions.
     ax.figure.canvas.draw()
@@ -214,7 +214,7 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None):
 
     # Set labels.
     ax.set_ylabel("Parallactic Angle - Radians")
-    ax.set_xlabel("Time")
+    ax.set_xlabel("Time - {0} [UTC]".format(min(time).datetime.date()))
 
     # Redraw figure for interactive sessions.
     ax.figure.canvas.draw()

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -113,7 +113,7 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None):
 
     # Set labels.
     ax.set_ylabel("Airmass")
-    ax.set_xlabel("Time - {0} [UTC]".format(min(time).datetime.date()))
+    ax.set_xlabel("Time from {0} [UTC]".format(min(time).datetime.date()))
 
     # Redraw figure for interactive sessions.
     ax.figure.canvas.draw()
@@ -214,7 +214,7 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None):
 
     # Set labels.
     ax.set_ylabel("Parallactic Angle - Radians")
-    ax.set_xlabel("Time - {0} [UTC]".format(min(time).datetime.date()))
+    ax.set_xlabel("Time from {0} [UTC]".format(min(time).datetime.date()))
 
     # Redraw figure for interactive sessions.
     ax.figure.canvas.draw()

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -68,6 +68,7 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None):
         2) Dark plot option.
     """
     import matplotlib.pyplot as plt
+    from matplotlib import dates
 
     # Set up plot axes and style if needed.
     if ax is None:
@@ -97,11 +98,13 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None):
         target_name = target.name
     style_kwargs.setdefault('label', target_name)
 
-    observe_timezone = ''
-
     # Plot data.
     ax.plot_date(time.plot_date, airmass, **style_kwargs)
-    ax.figure.autofmt_xdate()
+
+    # Format the time axis
+    date_formatter = dates.DateFormatter('%H:%M')
+    ax.xaxis.set_major_formatter(date_formatter)
+    plt.setp(ax.get_xticklabels(), rotation=30, ha='right')
 
     # Invert y-axis and set limits.
     if ax.get_ylim()[1] > ax.get_ylim()[0]:
@@ -110,7 +113,7 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None):
 
     # Set labels.
     ax.set_ylabel("Airmass")
-    ax.set_xlabel("Time - "+observe_timezone)
+    ax.set_xlabel("Time")
 
     # Redraw figure for interactive sessions.
     ax.figure.canvas.draw()
@@ -169,6 +172,7 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None):
         2) observe_timezone -- update with info from observer?
     """
     import matplotlib.pyplot as plt
+    from matplotlib import dates
 
     # Set up plot axes and style if needed.
     if ax is None:
@@ -200,15 +204,17 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None):
         target_name = target.name
     style_kwargs.setdefault('label', target_name)
 
-    observe_timezone = ''
-
     # Plot data.
     ax.plot_date(time.plot_date, p_angle, **style_kwargs)
-    ax.figure.autofmt_xdate()
+
+    # Format the time axis
+    date_formatter = dates.DateFormatter('%H:%M')
+    ax.xaxis.set_major_formatter(date_formatter)
+    plt.setp(ax.get_xticklabels(), rotation=30, ha='right')
 
     # Set labels.
     ax.set_ylabel("Parallactic Angle - Radians")
-    ax.set_xlabel("Time - "+observe_timezone)
+    ax.set_xlabel("Time")
 
     # Redraw figure for interactive sessions.
     ax.figure.canvas.draw()


### PR DESCRIPTION
After trying to make some demo plots using `astroplan.plots` I found some quirks to clean up. I wanted to make two subplots in one figure and noticed that the `ax.figure.autofmt_xdate()` call in `astroplan.plots.plot_airmass` is being applied to all axes within the figure, which means if you make two kinds of subplots in the same figure, you can get incorrectly rotated axis labels on other subplots like so 

![demo_bad](https://cloud.githubusercontent.com/assets/3497584/10402221/e5b11940-6e78-11e5-8097-5944446cbcfe.png)

Also, the time axis label in the airmass plot has a leftover hyphen in it, but doesn't show the date as I think it was supposed to. 

I've corrected these two bugs by writing a custom axis formatter and a new xlabel to go with it. The same plotting script now produces a plot like this: 

![demo_good](https://cloud.githubusercontent.com/assets/3497584/10402261/338b4690-6e79-11e5-94b4-4d4c0601974d.png)

cc @jberlanga @adrn