### PR TITLE
Mask out nonsense airmasses in plot_airmass

### DIFF
--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -90,6 +90,8 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None):
 
     # Calculate airmass
     airmass = observer.altaz(time, target).secz
+    # Mask out nonsense airmasses
+    masked_airmass = np.ma.array(airmass, mask=airmass < 0)
 
     # Some checks & info for labels.
     if not hasattr(target, 'name'):


### PR DESCRIPTION
The `astroplan.plots.plot_airmass` function calls `obs.altaz(time, target).secz`, which outputs airmass as a function of time. When the target is below the horizon, the outputs are negative (meaningless), and as a result vertical lines appear in the airmass plots at times when the target crosses the horizon. 

I've masked the airmass array to ignore negative airmasses in the plot, so that confusing vertical lines don't appear in the airmass plots, like this:
![demo_am_good](https://cloud.githubusercontent.com/assets/3497584/10402972/58d57958-6e7d-11e5-9bc1-d586e953d496.png)

cc @jberlanga @eteq 