### PR TITLE
Potential fix for #109

### DIFF
--- a/astroplan/moon.py
+++ b/astroplan/moon.py
@@ -69,8 +69,8 @@ def get_moon(time, location, pressure=None):
 
     moon = ephem.Moon()
     obs = ephem.Observer()
-    obs.lat = location.latitude.to(u.degree).to_string(sep=':')
-    obs.lon = location.longitude.to(u.degree).to_string(sep=':')
+    obs.lat = location.latitude.to_string(u.deg, sep=':')
+    obs.lon = location.longitude.to_string(u.deg, sep=':')
     obs.elevation = location.height.to(u.m).value
     if pressure is not None:
         obs.pressure = pressure.to(u.bar).value*1000.0

--- a/astroplan/tests/test_moon.py
+++ b/astroplan/tests/test_moon.py
@@ -47,8 +47,8 @@ def print_pyephem_illumination():
 
     moon = ephem.Moon()
     pe_obs = ephem.Observer()
-    pe_obs.lat = location.latitude.to(u.degree).to_string(sep=':')
-    pe_obs.lon = location.longitude.to(u.degree).to_string(sep=':')
+    pe_obs.lat = location.latitude.to_string(u.deg, sep=':')
+    pe_obs.lon = location.longitude.to_string(u.deg, sep=':')
     pe_obs.elevation = location.height.to(u.m).value
     illuminations = []
     for t in time:

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -255,17 +255,17 @@ def test_parallactic_angle():
     pyephem_q1 = 46.54610060782033*u.deg
     pyephem_q2 = -65.51818282032019*u.deg
 
-    assert_allclose(q1.to(u.degree).value, pyephem_q1, atol=1)
-    assert_allclose(q2.to(u.degree).value, pyephem_q2, atol=1)
+    assert_quantity_allclose(q1, pyephem_q1, atol=1*u.deg)
+    assert_quantity_allclose(q2, pyephem_q2, atol=1*u.deg)
 
     # Get SpeX parallactic angle calculator values for comparison from
     # http://irtfweb.ifa.hawaii.edu/cgi-bin/spex/parangle.cgi to produce
 
-    SpeX_q1 = 46.7237968 # deg
-    SpeX_q2 = -65.428924 # deg
+    SpeX_q1 = 46.7237968*u.deg # deg
+    SpeX_q2 = -65.428924*u.deg # deg
 
-    assert_allclose(q1.to(u.degree).value, SpeX_q1, atol=0.1)
-    assert_allclose(q2.to(u.degree).value, SpeX_q2, atol=0.1)
+    assert_quantity_allclose(q1, SpeX_q1, atol=0.1*u.deg)
+    assert_quantity_allclose(q2, SpeX_q2, atol=0.1*u.deg)
 
     assert q1 == q12[0]
     assert q2 == q12[1]


### PR DESCRIPTION
In #109 @cdeil found a few lines where I used a very convoluted unit conversion. I've updated the test in question to use a more straightforward unit conversion and fixed another bad test that I found for `Observer`, which wasn't doing proper unitful comparisons between expected input and output. 

@cdeil - would you mind testing this on your machine? It passes for me on Scientific Linux 6 with Python 2.7.