### PR TITLE
New style sheets for plots

### DIFF
--- a/astroplan/plots/__init__.py
+++ b/astroplan/plots/__init__.py
@@ -8,3 +8,4 @@ and `Matplotlib`_.
 
 from .time_dependent import *
 from .sky import *
+from .mplstyles import *

--- a/astroplan/plots/mplstyles.py
+++ b/astroplan/plots/mplstyles.py
@@ -2,23 +2,22 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import copy
+
 from astropy.visualization import astropy_mpl_style
 
 __all__ = ['light_style_sheet', 'dark_style_sheet',
            'available_style_sheets']
 
-available_styles = ["light_style_sheet", "dark_style_sheet"]
+available_style_sheets = ["light_style_sheet", "dark_style_sheet"]
+"""Matplotlib style sheets available within astroplan."""
 
-def available_style_sheets():
-    """
-    Matplotlib style sheets available within astroplan.
-    """
-    return available_styles
+light_style_sheet = copy.deepcopy(astropy_mpl_style)
 
 # One update specifically for astroplan.plots: raise bottom up from default 0.1
-astropy_mpl_style.update({'figure.subplot.bottom': 0.15})
-light_style_sheet = astropy_mpl_style
+light_style_sheet.update({'figure.subplot.bottom': 0.15})
 
+# Define dark style sheet starting from the astropy_mpl_style sheet
 dark_style_sheet = {
 
     # Lines

--- a/astroplan/plots/mplstyles.py
+++ b/astroplan/plots/mplstyles.py
@@ -7,7 +7,13 @@ from astropy.visualization import astropy_mpl_style
 __all__ = ['light_style_sheet', 'dark_style_sheet',
            'available_style_sheets']
 
-available_style_sheets = ["light_style_sheet", "dark_style_sheet"]
+available_styles = ["light_style_sheet", "dark_style_sheet"]
+
+def available_style_sheets():
+    """
+    Matplotlib style sheets available within astroplan.
+    """
+    return available_styles
 
 # One update specifically for astroplan.plots: raise bottom up from default 0.1
 astropy_mpl_style.update({'figure.subplot.bottom': 0.15})

--- a/astroplan/plots/mplstyles.py
+++ b/astroplan/plots/mplstyles.py
@@ -4,16 +4,16 @@ from __future__ import (absolute_import, division, print_function,
 
 from astropy.visualization import astropy_mpl_style
 
-__all__ = ['astroplan_light_style', 'astroplan_dark_style',
+__all__ = ['light_style_sheet', 'dark_style_sheet',
            'available_style_sheets']
 
-available_style_sheets = ["astroplan_light_style", "astroplan_dark_style"]
+available_style_sheets = ["light_style_sheet", "dark_style_sheet"]
 
 # One update specifically for astroplan.plots: raise bottom up from default 0.1
 astropy_mpl_style.update({'figure.subplot.bottom': 0.15})
-astroplan_light_style = astropy_mpl_style
+light_style_sheet = astropy_mpl_style
 
-astroplan_dark_style = {
+dark_style_sheet = {
 
     # Lines
     'lines.linewidth': 1.7,
@@ -41,10 +41,10 @@ astroplan_dark_style = {
     'axes.labelsize': 'large',
     'axes.labelcolor': 'w',
     'axes.axisbelow': True,
-    'axes.color_cycle': ['#00FFFF',   # blue
+    'axes.color_cycle': ['#00CCFF',   # blue
+                         '#FF0000',   # red
+                         '#40C000',   # green
                          '#E066E0',   # purple
-                         '#FF8080',   # red
-                         '#467821',   # green
                          '#CF4457',   # pink
                          '#188487',   # turquoise
                          '#E24A33'],  # orange

--- a/astroplan/plots/mplstyles.py
+++ b/astroplan/plots/mplstyles.py
@@ -1,0 +1,86 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from astropy.visualization import astropy_mpl_style
+
+__all__ = ['astroplan_light_style', 'astroplan_dark_style',
+           'available_style_sheets']
+
+available_style_sheets = ["astroplan_light_style", "astroplan_dark_style"]
+
+# One update specifically for astroplan.plots: raise bottom up from default 0.1
+astropy_mpl_style.update({'figure.subplot.bottom': 0.15})
+astroplan_light_style = astropy_mpl_style
+
+astroplan_dark_style = {
+
+    # Lines
+    'lines.linewidth': 1.7,
+    'lines.antialiased': True,
+
+    # Patches
+    'patch.linewidth': 1.0,
+    'patch.facecolor': 'k',
+    'patch.edgecolor': 'k',
+    'patch.antialiased': True,
+
+    # images
+    'image.cmap': 'gist_heat',
+    'image.origin': 'upper',
+
+    # Font
+    'font.size': 12.0,
+
+    # Axes
+    'axes.facecolor': '#000000',
+    'axes.edgecolor': '#F2F2F2',
+    'axes.linewidth': 1.0,
+    'axes.grid': True,
+    'axes.titlesize': 'x-large',
+    'axes.labelsize': 'large',
+    'axes.labelcolor': 'w',
+    'axes.axisbelow': True,
+    'axes.color_cycle': ['#00FFFF',   # blue
+                         '#E066E0',   # purple
+                         '#FF8080',   # red
+                         '#467821',   # green
+                         '#CF4457',   # pink
+                         '#188487',   # turquoise
+                         '#E24A33'],  # orange
+
+    # Ticks
+    'xtick.major.size': 0,
+    'xtick.minor.size': 0,
+    'xtick.major.pad': 6,
+    'xtick.minor.pad': 6,
+    'xtick.color': '#F2F2F2',
+    'xtick.direction': 'in',
+    'ytick.major.size': 0,
+    'ytick.minor.size': 0,
+    'ytick.major.pad': 6,
+    'ytick.minor.pad': 6,
+    'ytick.color': '#F2F2F2',
+    'ytick.direction': 'in',
+
+    # Legend
+    'legend.fancybox': True,
+    'legend.loc': 'best',
+
+    # Figure
+    'figure.figsize': [8, 6],
+    'figure.facecolor': 'k',
+    'figure.edgecolor': 'k',
+    'figure.subplot.hspace': 0.5,
+    'figure.subplot.bottom': 0.15,
+
+    # Saved figures
+    'savefig.dpi': 72,
+    'savefig.facecolor': 'k',
+    'savefig.edgecolor': 'k',
+    'savefig.transparent': False,
+
+    # Other
+    'grid.color': 'w',
+    'text.color': 'w'
+}

--- a/astroplan/plots/sky.py
+++ b/astroplan/plots/sky.py
@@ -8,7 +8,7 @@ from astropy.time import Time
 import warnings
 
 from ..exceptions import PlotBelowHorizonWarning
-from ..plots.mplstyles import (astroplan_light_style, astroplan_dark_style)
+from ..plots.mplstyles import (light_style_sheet, dark_style_sheet)
 
 __all__ = ['plot_sky', 'plot_sky_24hr']
 
@@ -107,7 +107,7 @@ def plot_sky(target, observer, time, ax=None, style_kwargs=None,
     """
     # Import matplotlib, set style sheet
     if style_sheet is None:
-        style_sheet = astroplan_light_style
+        style_sheet = light_style_sheet
     import matplotlib
     import matplotlib.pyplot as plt
     matplotlib.rcdefaults()

--- a/astroplan/plots/sky.py
+++ b/astroplan/plots/sky.py
@@ -8,7 +8,6 @@ from astropy.time import Time
 import warnings
 
 from ..exceptions import PlotBelowHorizonWarning
-from ..plots.mplstyles import light_style_sheet
 from ..utils import _set_mpl_style_sheet
 
 __all__ = ['plot_sky', 'plot_sky_24hr']
@@ -108,11 +107,10 @@ def plot_sky(target, observer, time, ax=None, style_kwargs=None,
         of azimuth (North from az = 0 deg., East from az = 90 deg., etc.).
     """
     # Import matplotlib, set style sheet
-    if style_sheet is None:
-        style_sheet = light_style_sheet
+    if style_sheet is not None:
+        _set_mpl_style_sheet(style_sheet)
 
     import matplotlib.pyplot as plt
-    _set_mpl_style_sheet(style_sheet)
 
     # Set up axes & plot styles if needed.
     if ax is None:

--- a/astroplan/plots/sky.py
+++ b/astroplan/plots/sky.py
@@ -8,6 +8,7 @@ from astropy.time import Time
 import warnings
 
 from ..exceptions import PlotBelowHorizonWarning
+from ..plots.mplstyles import (astroplan_light_style, astroplan_dark_style)
 
 __all__ = ['plot_sky', 'plot_sky_24hr']
 
@@ -15,7 +16,7 @@ __all__ = ['plot_sky', 'plot_sky_24hr']
 @u.quantity_input(az_label_offset=u.deg)
 def plot_sky(target, observer, time, ax=None, style_kwargs=None,
              north_to_east_ccw=True, grid=True, az_label_offset=0.0*u.deg,
-             warn_below_horizon=False):
+             warn_below_horizon=False, style_sheet=None):
     """
     Plots target positions in the sky with respect to the observer's location.
 
@@ -76,6 +77,10 @@ def plot_sky(target, observer, time, ax=None, style_kwargs=None,
         If `False`, don't show warnings when attempting to plot targets below
         the horzion.
 
+    style_sheet : dict or `None` (optional)
+        `~matplotlib` style sheet to use. To see available style sheets in
+        astroplan, print `~astroplan.plots.mplstyles.available_style_sheets`
+
     Returns
     -------
     An `~matplotlib.axes.Axes` object (ax) with a map of the sky.
@@ -100,7 +105,13 @@ def plot_sky(target, observer, time, ax=None, style_kwargs=None,
         makes it seem as if N/E/S/W are being decoupled from the definition
         of azimuth (North from az = 0 deg., East from az = 90 deg., etc.).
     """
+    # Import matplotlib, set style sheet
+    if style_sheet is None:
+        style_sheet = astroplan_light_style
+    import matplotlib
     import matplotlib.pyplot as plt
+    matplotlib.rcdefaults()
+    matplotlib.rcParams.update(style_sheet)
 
     # Set up axes & plot styles if needed.
     if ax is None:

--- a/astroplan/plots/sky.py
+++ b/astroplan/plots/sky.py
@@ -78,8 +78,8 @@ def plot_sky(target, observer, time, ax=None, style_kwargs=None,
         the horzion.
 
     style_sheet : dict or `None` (optional)
-        `~matplotlib` style sheet to use. To see available style sheets in
-        astroplan, print `~astroplan.plots.mplstyles.available_style_sheets`
+        matplotlib style sheet to use. To see available style sheets in
+        astroplan, print `~astroplan.plots.available_style_sheets()`
 
     Returns
     -------

--- a/astroplan/plots/sky.py
+++ b/astroplan/plots/sky.py
@@ -8,7 +8,8 @@ from astropy.time import Time
 import warnings
 
 from ..exceptions import PlotBelowHorizonWarning
-from ..plots.mplstyles import (light_style_sheet, dark_style_sheet)
+from ..plots.mplstyles import light_style_sheet
+from ..utils import _set_mpl_style_sheet
 
 __all__ = ['plot_sky', 'plot_sky_24hr']
 
@@ -79,7 +80,8 @@ def plot_sky(target, observer, time, ax=None, style_kwargs=None,
 
     style_sheet : dict or `None` (optional)
         matplotlib style sheet to use. To see available style sheets in
-        astroplan, print `~astroplan.plots.available_style_sheets()`
+        astroplan, print *astroplan.plots.available_style_sheets*. Defaults
+        to the light theme.
 
     Returns
     -------
@@ -108,10 +110,9 @@ def plot_sky(target, observer, time, ax=None, style_kwargs=None,
     # Import matplotlib, set style sheet
     if style_sheet is None:
         style_sheet = light_style_sheet
-    import matplotlib
+
     import matplotlib.pyplot as plt
-    matplotlib.rcdefaults()
-    matplotlib.rcParams.update(style_sheet)
+    _set_mpl_style_sheet(style_sheet)
 
     # Set up axes & plot styles if needed.
     if ax is None:

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -8,7 +8,6 @@ from astropy.time import Time
 import warnings
 
 from ..exceptions import PlotWarning
-from ..plots.mplstyles import light_style_sheet
 from ..utils import _set_mpl_style_sheet
 
 __all__ = ['plot_airmass', 'plot_parallactic']
@@ -75,12 +74,10 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None,
         1) Timezones?
     """
     # Import matplotlib, set style sheet
-    if style_sheet is None:
-        style_sheet = light_style_sheet
+    if style_sheet is not None:
+        _set_mpl_style_sheet(style_sheet)
 
     import matplotlib.pyplot as plt
-    _set_mpl_style_sheet(style_sheet)
-
     from matplotlib import dates
 
     # Set up plot axes and style if needed.
@@ -192,11 +189,10 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None,
         1) observe_timezone -- update with info from observer?
     """
     # Import matplotlib, set style sheet
-    if style_sheet is None:
-        style_sheet = light_style_sheet
+    if style_sheet is not None:
+        _set_mpl_style_sheet(style_sheet)
 
     import matplotlib.pyplot as plt
-    _set_mpl_style_sheet(style_sheet)
 
     from matplotlib import dates
 

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -8,7 +8,8 @@ from astropy.time import Time
 import warnings
 
 from ..exceptions import PlotWarning
-from ..plots.mplstyles import (light_style_sheet, dark_style_sheet)
+from ..plots.mplstyles import light_style_sheet
+from ..utils import _set_mpl_style_sheet
 
 __all__ = ['plot_airmass', 'plot_parallactic']
 
@@ -56,7 +57,8 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None,
 
     style_sheet : dict or `None` (optional)
         matplotlib style sheet to use. To see available style sheets in
-        astroplan, print `~astroplan.plots.available_style_sheets()`
+        astroplan, print *astroplan.plots.available_style_sheets*. Defaults
+        to the light theme.
 
     Returns
     -------
@@ -75,10 +77,9 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None,
     # Import matplotlib, set style sheet
     if style_sheet is None:
         style_sheet = light_style_sheet
-    import matplotlib
+
     import matplotlib.pyplot as plt
-    matplotlib.rcdefaults()
-    matplotlib.rcParams.update(style_sheet)
+    _set_mpl_style_sheet(style_sheet)
 
     from matplotlib import dates
 
@@ -179,7 +180,8 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None,
 
     style_sheet : dict or `None` (optional)
         matplotlib style sheet to use. To see available style sheets in
-        astroplan, print `~astroplan.plots.available_style_sheets()`
+        astroplan, print *astroplan.plots.available_style_sheets*. Defaults
+        to the light theme.
 
     Returns
     -------
@@ -192,10 +194,9 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None,
     # Import matplotlib, set style sheet
     if style_sheet is None:
         style_sheet = light_style_sheet
-    import matplotlib
+
     import matplotlib.pyplot as plt
-    matplotlib.rcdefaults()
-    matplotlib.rcParams.update(style_sheet)
+    _set_mpl_style_sheet(style_sheet)
 
     from matplotlib import dates
 

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -8,11 +8,13 @@ from astropy.time import Time
 import warnings
 
 from ..exceptions import PlotWarning
+from ..plots.mplstyles import (astroplan_light_style, astroplan_dark_style)
 
 __all__ = ['plot_airmass', 'plot_parallactic']
 
 
-def plot_airmass(target, observer, time, ax=None, style_kwargs=None):
+def plot_airmass(target, observer, time, ax=None, style_kwargs=None,
+                 style_sheet=None):
     """
     Plots airmass as a function of time for a given target.
 
@@ -52,6 +54,10 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None):
         A dictionary of keywords passed into `~matplotlib.pyplot.plot_date`
         to set plotting styles.
 
+    style_sheet : dict or `None` (optional)
+        `~matplotlib` style sheet to use. To see available style sheets in
+        astroplan, print `~astroplan.plots.mplstyles.available_style_sheets`
+
     Returns
     -------
     ax : `~matplotlib.axes.Axes`
@@ -67,7 +73,14 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None):
         1) Timezones?
         2) Dark plot option.
     """
+    # Import matplotlib, set style sheet
+    if style_sheet is None:
+        style_sheet = astroplan_light_style
+    import matplotlib
     import matplotlib.pyplot as plt
+    matplotlib.rcdefaults()
+    matplotlib.rcParams.update(style_sheet)
+
     from matplotlib import dates
 
     # Set up plot axes and style if needed.
@@ -124,7 +137,8 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None):
     return ax
 
 
-def plot_parallactic(target, observer, time, ax=None, style_kwargs=None):
+def plot_parallactic(target, observer, time, ax=None, style_kwargs=None,
+                     style_sheet=None):
     """
     Plots parallactic angle as a function of time for a given target.
 
@@ -164,6 +178,10 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None):
         A dictionary of keywords passed into `~matplotlib.pyplot.plot_date`
         to set plotting styles.
 
+    style_sheet : dict or `None` (optional)
+        `~matplotlib` style sheet to use. To see available style sheets in
+        astroplan, print `~astroplan.plots.mplstyles.available_style_sheets`
+
     Returns
     -------
     ax :  `~matplotlib.axes.Axes`
@@ -173,7 +191,14 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None):
         1) dark_plot style
         2) observe_timezone -- update with info from observer?
     """
+    # Import matplotlib, set style sheet
+    if style_sheet is None:
+        style_sheet = astroplan_light_style
+    import matplotlib
     import matplotlib.pyplot as plt
+    matplotlib.rcdefaults()
+    matplotlib.rcParams.update(style_sheet)
+
     from matplotlib import dates
 
     # Set up plot axes and style if needed.

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -104,7 +104,7 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None,
     # Calculate airmass
     airmass = observer.altaz(time, target).secz
     # Mask out nonsense airmasses
-    masked_airmass = np.ma.array(airmass, mask=airmass < 0)
+    masked_airmass = np.ma.array(airmass, mask=airmass < 1)
 
     # Some checks & info for labels.
     if not hasattr(target, 'name'):
@@ -114,7 +114,7 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None,
     style_kwargs.setdefault('label', target_name)
 
     # Plot data.
-    ax.plot_date(time.plot_date, airmass, **style_kwargs)
+    ax.plot_date(time.plot_date, masked_airmass, **style_kwargs)
 
     # Format the time axis
     date_formatter = dates.DateFormatter('%H:%M')

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -55,8 +55,8 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None,
         to set plotting styles.
 
     style_sheet : dict or `None` (optional)
-        `~matplotlib` style sheet to use. To see available style sheets in
-        astroplan, print `~astroplan.plots.mplstyles.available_style_sheets`
+        matplotlib style sheet to use. To see available style sheets in
+        astroplan, print `~astroplan.plots.available_style_sheets()`
 
     Returns
     -------
@@ -178,8 +178,8 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None,
         to set plotting styles.
 
     style_sheet : dict or `None` (optional)
-        `~matplotlib` style sheet to use. To see available style sheets in
-        astroplan, print `~astroplan.plots.mplstyles.available_style_sheets`
+        matplotlib style sheet to use. To see available style sheets in
+        astroplan, print `~astroplan.plots.available_style_sheets()`
 
     Returns
     -------

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -8,7 +8,7 @@ from astropy.time import Time
 import warnings
 
 from ..exceptions import PlotWarning
-from ..plots.mplstyles import (astroplan_light_style, astroplan_dark_style)
+from ..plots.mplstyles import (light_style_sheet, dark_style_sheet)
 
 __all__ = ['plot_airmass', 'plot_parallactic']
 
@@ -71,11 +71,10 @@ def plot_airmass(target, observer, time, ax=None, style_kwargs=None,
 
     TODO:
         1) Timezones?
-        2) Dark plot option.
     """
     # Import matplotlib, set style sheet
     if style_sheet is None:
-        style_sheet = astroplan_light_style
+        style_sheet = light_style_sheet
     import matplotlib
     import matplotlib.pyplot as plt
     matplotlib.rcdefaults()
@@ -188,12 +187,11 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None,
         An ``Axes`` object with added parallactic angle vs. time plot.
 
     TODO:
-        1) dark_plot style
-        2) observe_timezone -- update with info from observer?
+        1) observe_timezone -- update with info from observer?
     """
     # Import matplotlib, set style sheet
     if style_sheet is None:
-        style_sheet = astroplan_light_style
+        style_sheet = light_style_sheet
     import matplotlib
     import matplotlib.pyplot as plt
     matplotlib.rcdefaults()

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -18,7 +18,7 @@ from astropy.utils.data import (_get_download_cache_locs, CacheMissingWarning,
 from .exceptions import OldEarthOrientationDataWarning
 
 __all__ = ["get_IERS_A_or_workaround", "download_IERS_A",
-           "time_grid_from_range"]
+           "time_grid_from_range", "_set_mpl_style_sheet"]
 
 IERS_A_WARNING = ("For best precision (on the order of arcseconds), you must "
                   "download an up-to-date IERS Bulletin A table. To do so, run:"
@@ -187,3 +187,13 @@ def _unmock_remote_data():
         FixedTarget.from_name = FixedTarget._real_from_name
         del FixedTarget._real_from_name
     # otherwise assume it's already correct
+
+def _set_mpl_style_sheet(style_sheet):
+    """
+    Import matplotlib, set the style sheet to ``style_sheet`` using
+    the most backward compatible import pattern.
+    """
+    import matplotlib
+    matplotlib.rcdefaults()
+    matplotlib.rcParams.update(style_sheet)
+

--- a/docs/tutorials/plots.rst
+++ b/docs/tutorials/plots.rst
@@ -406,8 +406,8 @@ The default line for time-dependent plots is solid and the default label
 See the `Matplotlib`_ documentation for information on plotting styles in line
 plots.
 
-Night vision mode
-+++++++++++++++++
+Dark Theme Plots
+++++++++++++++++
 
 By default, `astroplan` uses the `astropy`_ style sheet for `Matplotlib`_ to
 generate plots with more pleasing settings than provided for by the matplotlib

--- a/docs/tutorials/plots.rst
+++ b/docs/tutorials/plots.rst
@@ -406,6 +406,43 @@ The default line for time-dependent plots is solid and the default label
 See the `Matplotlib`_ documentation for information on plotting styles in line
 plots.
 
+Night vision mode
++++++++++++++++++
+
+By default, `astroplan` uses the `astropy`_ style sheet for `Matplotlib`_ to
+generate plots with more pleasing settings than provided for by the matplotlib
+defaults. When using `astroplan` at night, you may prefer to make plots with
+dark backgrounds, rather than the default white background, to preserve your
+night vision. To do so, you may use the `astroplan` dark style sheet to
+produce dark-themed plots by using the *style_sheet* keyword argument in
+any plotting function:
+
+.. code-block:: python
+
+    >>> from astroplan.plots import dark_style_sheet
+    >>> plot_airmass(target, observatory, time, style_sheet=dark_style_sheet)
+
+
+.. plot::
+
+    from astropy.time import Time
+    from astropy.coordinates import SkyCoord
+    import astropy.units as u
+
+    from astroplan.plots import plot_airmass, dark_style_sheet
+    from astroplan import Observer, FixedTarget
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    vega = FixedTarget(coord=SkyCoord(ra=279.23473479*u.deg, dec=38.78368896*u.deg))
+    apo = Observer.at_site('APO')
+
+    plot_airmass(vega, apo, Time('2005-01-02 19:00') + np.linspace(-5, 5, 20)*u.hour,
+                 style_sheet=dark_style_sheet)
+    plt.show()
+
+
 :ref:`Return to Top <plots>`
 
 
@@ -628,6 +665,7 @@ Customizing your sky plot
 
 `astroplan` plots use `Matplotlib`_ defaults, so you can customize your plots in
 much the same way you tweak any `Matplotlib`_ plot.
+
 
 Setting style options
 +++++++++++++++++++++

--- a/docs/tutorials/plots.rst
+++ b/docs/tutorials/plots.rst
@@ -419,7 +419,7 @@ any plotting function:
 
 .. code-block:: python
 
-    >>> from astroplan.plots import dark_style_sheet
+    >>> from astroplan.plots import dark_style_sheet, plot_airmass
     >>> plot_airmass(target, observatory, time, style_sheet=dark_style_sheet)
 
 


### PR DESCRIPTION
~~I've set `astroplan`'s default style sheet to be the `astropy.visualization` default style sheet~~ (update: I've undone that, see [later notes](https://github.com/astropy/astroplan/pull/127#issuecomment-149607838)), and created my own version of the astropy style sheet with a dark background for the "night mode" that we've long sought after. This should close #74. For example, here's what the airmass plot looks like now in "light" mode: 
![airmass_default](https://cloud.githubusercontent.com/assets/3497584/10531297/180080f2-7365-11e5-99ef-c4804e159ea9.png)

and in "dark" mode: 
![airmass](https://cloud.githubusercontent.com/assets/3497584/10531280/f7e9203a-7364-11e5-92eb-5fe2538a0832.png)

I've added a note in the plotting tutorial on how to switch between them.

cc @jberlanga @ejeschke @adrn 

