### PR TITLE
Adding plot_finder_image docs, importing it into astroplan.plots namespace

### DIFF
--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -54,7 +54,7 @@ fi
 if [[ $SETUP_CMD == build_sphinx* ]]
 then
   $CONDA_INSTALL matplotlib Sphinx Pygments sphinx_rtd_theme
-  pip install wcsaxes
+  pip install wcsaxes astroquery
 fi
 
 # COVERAGE DEPENDENCIES

--- a/astroplan/plots/__init__.py
+++ b/astroplan/plots/__init__.py
@@ -9,3 +9,4 @@ and `Matplotlib`_.
 from .time_dependent import *
 from .sky import *
 from .mplstyles import *
+from .finder import *

--- a/astroplan/plots/finder.py
+++ b/astroplan/plots/finder.py
@@ -73,7 +73,7 @@ def plot_finder_image(target, survey='DSS', fov_radius=10*u.arcmin,
     Notes
     -----
     Dependencies:
-        In addition to Matplotlib, this function makes use of astroquery.
+        In addition to Matplotlib, this function makes use of astroquery and WCSAxes.
     """
 
     import matplotlib.pyplot as plt

--- a/astroplan/plots/finder.py
+++ b/astroplan/plots/finder.py
@@ -9,6 +9,8 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.wcs import WCS
 
+__all__ = ['plot_finder_image']
+
 @u.quantity_input(fov_radius=u.deg)
 def plot_finder_image(target, survey='DSS', fov_radius=10*u.arcmin,
                       log=False, ax=None, grid=False, reticle=False,
@@ -17,7 +19,7 @@ def plot_finder_image(target, survey='DSS', fov_radius=10*u.arcmin,
     Plot survey image centered on ``target``.
 
     Survey images are retrieved from NASA Goddard's SkyView service via
-    `~astroquery.skyview.SkyView`, and plotted using WCSAxes.
+    ``astroquery.skyview.SkyView``.
 
     If a `~matplotlib.axes.Axes` object already exists, plots the finder image
     on top. Otherwise, creates a new `~matplotlib.axes.Axes`
@@ -31,8 +33,8 @@ def plot_finder_image(target, survey='DSS', fov_radius=10*u.arcmin,
     survey : string
         Name of survey to retrieve image from. For dictionary of
         available surveys, use
-        `from astroquery.skyview import SkyView; print(SkyView.survey_dict)`.
-        Defaults to `'DSS'`, the Digital Sky Survey.
+        ``from astroquery.skyview import SkyView; SkyView.list_surveys()``.
+        Defaults to ``'DSS'``, the Digital Sky Survey.
 
     fov_radius : `~astropy.units.Quantity`
         Radius of field of view of retrieved image. Defaults to 10 arcmin.
@@ -66,6 +68,12 @@ def plot_finder_image(target, survey='DSS', fov_radius=10*u.arcmin,
 
     hdu : `~astropy.io.fits.PrimaryHDU`
         FITS HDU of the retrieved image
+
+
+    Notes
+    -----
+    Dependencies:
+        In addition to Matplotlib, this function makes use of astroquery.
     """
 
     import matplotlib.pyplot as plt

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,6 +21,8 @@ Optional packages:
 
 * `PyEphem`_
 * `Matplotlib`_
+* `WCSAxes`_
+* `astroquery`_
 
 First-time Python users may want to consider an all-in-one Python installation
 package, such as the `Anaconda Python Distribution

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -6,3 +6,5 @@
 .. _pytz: https://pypi.python.org/pypi/pytz/
 .. _pytest-mpl: https://pypi.python.org/pypi/pytest-mpl
 .. _Nose: https://nose.readthedocs.org
+.. _WCSAxes: https://wcsaxes.readthedocs.org
+.. _astroquery: https://astroquery.readthedocs.org

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -4,3 +4,4 @@ Cython
 astropy-helpers
 astropy >= 1.0
 pytz
+astroquery

--- a/docs/tutorials/plots.rst
+++ b/docs/tutorials/plots.rst
@@ -28,6 +28,8 @@ Contents
 
     * :ref:`plots_sky_charts`
 
+    * :ref:`finder_image`
+
 .. warning::
 
     All examples here assume you know how to and have already constructed
@@ -1057,3 +1059,39 @@ make multiple plots:
     plt.show()
 
 :ref:`Return to Top <plots>`
+
+.. _finder_image:
+
+Finder Chart/Image
+==================
+
+`astroplan` includes a function for generating quick finder images from the
+command line, `~astroplan.plots.plot_finder_image`, by querying for images from
+sky surveys centered on a `~astroplan.FixedTarget`. This function depends on
+`astroquery <https://astroquery.readthedocs.org/en/latest/>`_  (in addition
+to `Matplotlib`_). In this example, we'll quickly make a finder image centered
+on The Crab Nebula (M1):
+
+.. code-block:: python
+
+    >>> from astroplan.plots import plot_finder_image
+    >>> from astroplan import FixedTarget
+    >>> import matplotlib.pyplot as plt
+
+    >>> messier1 = FixedTarget.from_name("M1")
+    >>> ax, hdu = plot_finder_image(messier1)
+    >>> plt.show()
+
+.. plot::
+
+    from astroplan import FixedTarget
+    from astroplan.plots import plot_finder_image
+    import matplotlib.pyplot as plt
+
+    messier1 = FixedTarget.from_name("M1")
+    ax, hdu = plot_finder_image(messier1)
+    plt.show()
+
+
+:ref:`Return to Top <plots>`
+

--- a/docs/tutorials/plots.rst
+++ b/docs/tutorials/plots.rst
@@ -1065,11 +1065,11 @@ make multiple plots:
 Finder Chart/Image
 ==================
 
-`astroplan` includes a function for generating quick finder images from the
-command line, `~astroplan.plots.plot_finder_image`, by querying for images from
+`astroplan` includes a function for generating quick finder images from
+Python, `~astroplan.plots.plot_finder_image`, by querying for images from
 sky surveys centered on a `~astroplan.FixedTarget`. This function depends on
-`astroquery <https://astroquery.readthedocs.org/en/latest/>`_  (in addition
-to `Matplotlib`_). In this example, we'll quickly make a finder image centered
+`astroquery`_  (in addition
+to `Matplotlib`_ and `WCSAxes`_). In this example, we'll quickly make a finder image centered
 on The Crab Nebula (M1):
 
 .. code-block:: python


### PR DESCRIPTION
There was a mistake and an omission in PR #115 -- `plot_finder_image` was not imported into the `astroplan.plots` namespace, and no plotting tutorials were added to the docs (Issue #129). This PR seeks to fix both of those things, while cleaning up the function's docstring.

I've assigned @cdeil -- if I'm being presumptuous you don't have a few minutes to take a look in the next day or so let me know.

cc @tobyrsmith