### PR TITLE
Updating .travis to reflect recent miniconda changes

### DIFF
--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -x
 
+hash -r
+conda config --set always_yes yes --set changeps1 no
+conda update -q conda
+conda info -a
+
 # CONDA
 conda create --yes -n test -c astropy-ci-extras python=$PYTHON_VERSION pip
 source activate test
@@ -50,7 +55,7 @@ then
 fi
 
 # DOCUMENTATION DEPENDENCIES
-# build_sphinx needs sphinx as well as matplotlib and wcsaxes (for plot_directive). 
+# build_sphinx needs sphinx as well as matplotlib and wcsaxes (for plot_directive).
 if [[ $SETUP_CMD == build_sphinx* ]]
 then
   $CONDA_INSTALL matplotlib Sphinx Pygments sphinx_rtd_theme

--- a/.continuous-integration/travis/setup_environment_linux.sh
+++ b/.continuous-integration/travis/setup_environment_linux.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # Install conda
+
+# http://conda.pydata.org/docs/travis.html#the-travis-yml-file
 wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-chmod +x miniconda.sh
-./miniconda.sh -b
-export PATH=/home/travis/miniconda/bin:$PATH
-conda update --yes conda
+bash miniconda.sh -b -p $HOME/miniconda
+export PATH="$HOME/miniconda/bin:$PATH"
 
 # Install Python dependencies
 source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies_common.sh

--- a/.continuous-integration/travis/setup_environment_osx.sh
+++ b/.continuous-integration/travis/setup_environment_osx.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # Install conda
+
+# http://conda.pydata.org/docs/travis.html#the-travis-yml-file
 wget http://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -O miniconda.sh
-chmod +x miniconda.sh
-./miniconda.sh -b
-export PATH=/Users/travis/miniconda/bin:$PATH
-conda update --yes conda
+bash miniconda.sh -b -p $HOME/miniconda
+export PATH="$HOME/miniconda/bin:$PATH"
 
 # Install Python dependencies
 source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies_common.sh

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -409,7 +409,7 @@ class _Bootstrapper(object):
     def get_index_dist(self):
         if not self.download:
             log.warn('Downloading {0!r} disabled.'.format(DIST_NAME))
-            return False
+            return None
 
         log.warn(
             "Downloading {0!r}; run setup.py with the --offline option to "


### PR DESCRIPTION
Miniconda's default prefix changed recently causing all travis builds failing.