### PR TITLE
Better shape handling in constraints [#134]

### DIFF
--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -511,7 +511,8 @@ def is_always_observable(constraints, observer, targets, times=None,
     targets_is_scalar = False
     times_is_scalar = False
 
-    if not hasattr(targets, '__len__'):
+    if (not hasattr(targets, '__len__') or
+        (hasattr(targets, 'isscalar') and targets.isscalar)):
         targets = [targets]
         targets_is_scalar = True
 
@@ -579,7 +580,8 @@ def is_observable(constraints, observer, targets, times=None,
     targets_is_scalar = False
     times_is_scalar = False
 
-    if not hasattr(targets, '__len__'):
+    if (not hasattr(targets, '__len__') or
+        (hasattr(targets, 'isscalar') and targets.isscalar)):
         targets = [targets]
         targets_is_scalar = True
 

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -526,9 +526,9 @@ def is_always_observable(constraints, observer, targets, times=None,
                                       time_range=time_range,
                                       time_grid_resolution=time_grid_resolution)
                            for constraint in constraints]
-    contraint_arr = np.logical_and.reduce(applied_constraints)
+    constraint_arr = np.logical_and.reduce(applied_constraints)
 
-    always_observable = np.all(contraint_arr, axis=1)
+    always_observable = np.all(constraint_arr, axis=1)
 
     if targets_is_scalar and times_is_scalar:
         return always_observable.ravel()[0]
@@ -595,9 +595,9 @@ def is_observable(constraints, observer, targets, times=None,
                                       time_range=time_range,
                                       time_grid_resolution=time_grid_resolution)
                            for constraint in constraints]
-    contraint_arr = np.logical_and.reduce(applied_constraints)
+    constraint_arr = np.logical_and.reduce(applied_constraints)
 
-    ever_observable = np.any(contraint_arr, axis=1)
+    ever_observable = np.any(constraint_arr, axis=1)
 
     if targets_is_scalar and times_is_scalar:
         return ever_observable.ravel()[0]

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -508,15 +508,35 @@ def is_always_observable(constraints, observer, targets, times=None,
         List of booleans of same length as ``targets`` for whether or not each
         target is observable in the time range given the constraints.
     """
+    targets_is_scalar = False
+    times_is_scalar = False
+
+    if not hasattr(targets, '__len__'):
+        targets = [targets]
+        targets_is_scalar = True
+
     if not hasattr(constraints, '__len__'):
         constraints = [constraints]
+
+    if not hasattr(times, '__len__') or not hasattr(time_range, '__len__'):
+        times_is_scalar = True
 
     applied_constraints = [constraint(observer, targets, times=times,
                                       time_range=time_range,
                                       time_grid_resolution=time_grid_resolution)
                            for constraint in constraints]
     contraint_arr = np.logical_and.reduce(applied_constraints)
-    return np.all(contraint_arr, axis=1)
+
+    always_observable = np.all(contraint_arr, axis=1)
+
+    if targets_is_scalar and times_is_scalar:
+        return always_observable.ravel()[0]
+
+    elif targets_is_scalar:
+        return always_observable[:, 0]
+
+    else:
+        return always_observable
 
 
 def is_observable(constraints, observer, targets, times=None,
@@ -556,15 +576,35 @@ def is_observable(constraints, observer, targets, times=None,
         List of booleans of same length as ``targets`` for whether or not each
         target is ever observable in the time range given the constraints.
     """
+    targets_is_scalar = False
+    times_is_scalar = False
+
+    if not hasattr(targets, '__len__'):
+        targets = [targets]
+        targets_is_scalar = True
+
     if not hasattr(constraints, '__len__'):
         constraints = [constraints]
+
+    if not hasattr(times, '__len__') or not hasattr(time_range, '__len__'):
+        times_is_scalar = True
 
     applied_constraints = [constraint(observer, targets, times=times,
                                       time_range=time_range,
                                       time_grid_resolution=time_grid_resolution)
                            for constraint in constraints]
     contraint_arr = np.logical_and.reduce(applied_constraints)
-    return np.any(contraint_arr, axis=1)
+
+    ever_observable = np.any(contraint_arr, axis=1)
+
+    if targets_is_scalar and times_is_scalar:
+        return ever_observable.ravel()[0]
+
+    elif targets_is_scalar:
+        return ever_observable[:, 0]
+
+    else:
+        return ever_observable
 
 def observability_table(constraints, observer, targets, times=None,
                         time_range=None, time_grid_resolution=0.5*u.hour):

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -134,6 +134,75 @@ def test_compare_airmass_constraint_and_observer():
 
 #in astropy before v1.0.4, a recursion error is triggered by this test
 @pytest.mark.skipif('APY_LT104')
+
+def test_always_observable_shape():
+    # Scalar time, scalar target
+    scalar_time = Time('2001-02-03 04:05:06')
+    non_scalar_time = (Time('2001-02-03 04:05:06') +
+                       u.Quantity([0, 1, 2, 3], unit=u.min))
+    subaru = Observer.at_site("Subaru")
+    scalar_target = vega
+    non_scalar_target = [vega, rigel, polaris]
+
+    always1 = is_always_observable(AirmassConstraint(max=2),
+                                   subaru, scalar_target,
+                                   times=scalar_time)
+    assert always1.shape == ()
+
+    # Scalar time, non-scalar target
+    always2 = is_always_observable(AirmassConstraint(max=2),
+                                   subaru, non_scalar_target,
+                                   times=scalar_time)
+
+    assert always2.shape == (len(non_scalar_target),)
+
+    # Non-scalar time, scalar target
+    always3 = is_always_observable(AirmassConstraint(max=2),
+                                   subaru, non_scalar_target,
+                                   times=scalar_time)
+    assert always3.shape == (len(non_scalar_target), )
+
+    # non-scalar time, non-scalar target
+    always4 = is_always_observable(AirmassConstraint(max=2),
+                                   subaru, non_scalar_target,
+                                   times=non_scalar_time)
+
+    assert always4.shape == (len(non_scalar_target), )
+
+def test_ever_observable_shape():
+    # Scalar time, scalar target
+    scalar_time = Time('2001-02-03 04:05:06')
+    non_scalar_time = (Time('2001-02-03 04:05:06') +
+                       u.Quantity([0, 1, 2, 3], unit=u.min))
+    subaru = Observer.at_site("Subaru")
+    scalar_target = vega
+    non_scalar_target = [vega, rigel, polaris]
+
+    ever1 = is_observable(AirmassConstraint(max=2),
+                          subaru, scalar_target,
+                          times=scalar_time)
+    assert ever1.shape == ()
+
+    # Scalar time, non-scalar target
+    ever2 = is_observable(AirmassConstraint(max=2),
+                          subaru, non_scalar_target,
+                          times=scalar_time)
+
+    assert ever2.shape == (len(non_scalar_target),)
+
+    # Non-scalar time, scalar target
+    ever3 = is_observable(AirmassConstraint(max=2),
+                          subaru, non_scalar_target,
+                          times=scalar_time)
+    assert ever3.shape == (len(non_scalar_target), )
+
+    # non-scalar time, non-scalar target
+    ever4 = is_observable(AirmassConstraint(max=2),
+                          subaru, non_scalar_target,
+                          times=non_scalar_time)
+
+    assert ever4.shape == (len(non_scalar_target), )
+
 def test_sun_separation():
     time = Time('2003-04-05 06:07:08')
     apo = Observer.at_site("APO")

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -141,33 +141,49 @@ def test_always_observable_shape():
     non_scalar_time = (Time('2001-02-03 04:05:06') +
                        u.Quantity([0, 1, 2, 3], unit=u.min))
     subaru = Observer.at_site("Subaru")
-    scalar_target = vega
-    non_scalar_target = [vega, rigel, polaris]
+    scalar_target_ft = vega
+    scalar_target_sc = vega.coord
+    non_scalar_target_ft = [vega, rigel, polaris]
+    non_scalar_target_sc = SkyCoord([vega.coord, rigel.coord, polaris.coord])
 
-    always1 = is_always_observable(AirmassConstraint(max=2),
-                                   subaru, scalar_target,
-                                   times=scalar_time)
-    assert always1.shape == ()
+    always1_ft = is_always_observable(AirmassConstraint(max=2),
+                                      subaru, scalar_target_ft,
+                                      times=scalar_time)
+    always1_sc = is_always_observable(AirmassConstraint(max=2),
+                                      subaru, scalar_target_sc,
+                                      times=scalar_time)
+    assert always1_ft.shape == ()
+    assert always1_sc.shape == ()
 
     # Scalar time, non-scalar target
-    always2 = is_always_observable(AirmassConstraint(max=2),
-                                   subaru, non_scalar_target,
-                                   times=scalar_time)
-
-    assert always2.shape == (len(non_scalar_target),)
+    always2_ft = is_always_observable(AirmassConstraint(max=2),
+                                      subaru, non_scalar_target_ft,
+                                      times=scalar_time)
+    always2_sc = is_always_observable(AirmassConstraint(max=2),
+                                      subaru, non_scalar_target_sc,
+                                      times=scalar_time)
+    assert always2_ft.shape == (len(non_scalar_target_ft), )
+    assert always2_sc.shape == (len(non_scalar_target_sc), )
 
     # Non-scalar time, scalar target
-    always3 = is_always_observable(AirmassConstraint(max=2),
-                                   subaru, non_scalar_target,
-                                   times=scalar_time)
-    assert always3.shape == (len(non_scalar_target), )
+    always3_ft = is_always_observable(AirmassConstraint(max=2),
+                                      subaru, scalar_target_ft,
+                                      times=non_scalar_time)
+    always3_sc = is_always_observable(AirmassConstraint(max=2),
+                                      subaru, scalar_target_sc,
+                                      times=non_scalar_time)
+    assert always3_ft.shape == ()
+    assert always3_sc.shape == ()
 
     # non-scalar time, non-scalar target
-    always4 = is_always_observable(AirmassConstraint(max=2),
-                                   subaru, non_scalar_target,
-                                   times=non_scalar_time)
-
-    assert always4.shape == (len(non_scalar_target), )
+    always4_ft = is_always_observable(AirmassConstraint(max=2),
+                                      subaru, non_scalar_target_ft,
+                                      times=non_scalar_time)
+    always4_sc = is_always_observable(AirmassConstraint(max=2),
+                                      subaru, non_scalar_target_sc,
+                                      times=non_scalar_time)
+    assert always4_ft.shape == (len(non_scalar_target_ft), )
+    assert always4_sc.shape == (len(non_scalar_target_sc), )
 
 def test_ever_observable_shape():
     # Scalar time, scalar target
@@ -175,33 +191,50 @@ def test_ever_observable_shape():
     non_scalar_time = (Time('2001-02-03 04:05:06') +
                        u.Quantity([0, 1, 2, 3], unit=u.min))
     subaru = Observer.at_site("Subaru")
-    scalar_target = vega
-    non_scalar_target = [vega, rigel, polaris]
+    scalar_target_ft = vega
+    scalar_target_sc = vega.coord
+    non_scalar_target_ft = [vega, rigel, polaris]
+    non_scalar_target_sc = SkyCoord([vega.coord, rigel.coord, polaris.coord])
 
-    ever1 = is_observable(AirmassConstraint(max=2),
-                          subaru, scalar_target,
-                          times=scalar_time)
-    assert ever1.shape == ()
+    # Scalar time, scalar target
+    ever1_ft = is_observable(AirmassConstraint(max=2),
+                             subaru, scalar_target_ft,
+                             times=scalar_time)
+    ever1_sc = is_observable(AirmassConstraint(max=2),
+                             subaru, scalar_target_sc,
+                             times=scalar_time)
+    assert ever1_ft.shape == ()
+    assert ever1_sc.shape == ()
 
     # Scalar time, non-scalar target
-    ever2 = is_observable(AirmassConstraint(max=2),
-                          subaru, non_scalar_target,
-                          times=scalar_time)
-
-    assert ever2.shape == (len(non_scalar_target),)
+    ever2_ft = is_observable(AirmassConstraint(max=2),
+                             subaru, non_scalar_target_ft,
+                             times=scalar_time)
+    ever2_sc = is_observable(AirmassConstraint(max=2),
+                             subaru, non_scalar_target_sc,
+                             times=scalar_time)
+    assert ever2_ft.shape == (len(non_scalar_target_ft),)
+    assert ever2_sc.shape == (len(non_scalar_target_sc),)
 
     # Non-scalar time, scalar target
-    ever3 = is_observable(AirmassConstraint(max=2),
-                          subaru, non_scalar_target,
-                          times=scalar_time)
-    assert ever3.shape == (len(non_scalar_target), )
+    ever3_ft = is_observable(AirmassConstraint(max=2),
+                             subaru, scalar_target_ft,
+                             times=non_scalar_time)
+    ever3_sc = is_observable(AirmassConstraint(max=2),
+                             subaru, scalar_target_sc,
+                             times=non_scalar_time)
+    assert ever3_ft.shape == ()
+    assert ever3_sc.shape == ()
 
     # non-scalar time, non-scalar target
-    ever4 = is_observable(AirmassConstraint(max=2),
-                          subaru, non_scalar_target,
-                          times=non_scalar_time)
-
-    assert ever4.shape == (len(non_scalar_target), )
+    ever4_ft = is_observable(AirmassConstraint(max=2),
+                             subaru, non_scalar_target_ft,
+                             times=non_scalar_time)
+    ever4_sc = is_observable(AirmassConstraint(max=2),
+                             subaru, non_scalar_target_sc,
+                             times=non_scalar_time)
+    assert ever4_ft.shape == (len(non_scalar_target_ft), )
+    assert ever4_sc.shape == (len(non_scalar_target_sc), )
 
 def test_sun_separation():
     time = Time('2003-04-05 06:07:08')

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -389,9 +389,11 @@ def test_docs_example():
         def compute_constraint(self, times, observer, targets):
 
             # Vega's coordinate must be non-scalar for the dimensions
-            # to work out properly when combined with other constraints which
-            # test multiple times
-            vega = SkyCoord(ra=[279.23473479]*u.deg, dec=[38.78368896]*u.deg)
+            # to work out properly when the constraint accepts multiple
+            # input times. Since Vega's position doesn't depend on
+            # time, we'll enter the same coordinates for each time.
+            vega = SkyCoord(ra=len(times)*[279.23473479*u.deg],
+                            dec=len(times)*[38.78368896*u.deg])
 
             # Calculate separation between target and vega
             vega_separation = Angle([vega.separation(target.coord)
@@ -418,8 +420,8 @@ def test_docs_example():
             # False where it is not
             return mask
 
-    constraints = [VegaSeparationConstraint(min=5*u.deg, max=30*u.deg)]
-    observability = is_observable(constraints, subaru, targets,
+    constraint = VegaSeparationConstraint(min=5*u.deg, max=30*u.deg)
+    observability = is_observable(constraint, subaru, targets,
                                   time_range=time_range)
 
     assert all(observability == [False, False, True, False, False, False])

--- a/docs/tutorials/constraints.rst
+++ b/docs/tutorials/constraints.rst
@@ -261,9 +261,11 @@ Here's our ``VegaSeparationConstraint`` implementation::
         def compute_constraint(self, times, observer, targets):
 
             # Vega's coordinate must be non-scalar for the dimensions
-            # to work out properly when combined with other constraints which
-            # test multiple times
-            vega = SkyCoord(ra=[279.23473479]*u.deg, dec=[38.78368896]*u.deg)
+            # to work out properly when the constraint accepts multiple
+            # input times. Since Vega's position doesn't depend on
+            # time, we'll enter the same coordinates for each time.
+            vega = SkyCoord(ra=len(times)*[279.23473479*u.deg],
+                            dec=len(times)*[38.78368896*u.deg])
 
             # Calculate separation between target and vega
             vega_separation = Angle([vega.separation(target.coord)
@@ -292,8 +294,8 @@ Here's our ``VegaSeparationConstraint`` implementation::
 
 Then as in the earlier example, we can call our constraint::
 
-    >>> constraints = [VegaSeparationConstraint(min=5*u.deg, max=30*u.deg)]
-    >>> observability = is_observable(constraints, subaru, targets,
+    >>> constraint = VegaSeparationConstraint(min=5*u.deg, max=30*u.deg)
+    >>> observability = is_observable(constraint, subaru, targets,
     ...                               time_range=time_range)
     >>> print(observability)
     [False False  True False False False]


### PR DESCRIPTION
This addresses #134, which showed that some shapes of inputs to the `is_observable` and `is_always_observable` functions produced non-intuitive outputs. 

I catch the scalar input case and ensure appropriately scalar outputs now. Would @eteq volunteer to do the quick review? 

The ci tests should fail due to the unrelated issue #138, but the new constraints tests should pass.