### PR TITLE
Fix airmass constraint when no min is present for targets below horizon

### DIFF
--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -160,30 +160,32 @@ class AirmassConstraint(AltitudeConstraint):
 
     In the current implementation the airmass is approximated by the secant of
     the zenith angle.
+
+    .. note::
+        The ``max`` and ``min`` arguments appear in the order (max, min)
+        in this initializer to support the common case for users who care
+        about the upper limit on the airmass (``max``) and not the lower
+        limit.  For the same reason, if ``max`` is given without ``min``, the
+        default ``min`` is 0, not ``None``
+
+    Parameters
+    ----------
+    max : float or `None`
+        Maximum airmass of the target. `None` indicates no limit.
+
+    min : float or `None`
+        Minimum airmass of the target. `None` indicates no limit.  Note that in
+        the `None` case, this will mean *negative* airmasses (below the horizon)
+        are accepted.
+
+    Examples
+    --------
+    To create a constraint that requires the airmass be "better than 2",
+    i.e. at a higher altitude than airmass=2::
+
+        AirmassConstraint(2)
     """
-    def __init__(self, max=None, min=None):
-        """
-        .. note::
-            The ``max`` and ``min`` arguments appear in the order (max, min)
-            in this initializer to support the common case for users who care
-            about the upper limit on the airmass (``max``) and not the lower
-            limit.
-
-        Parameters
-        ----------
-        max : float or `None`
-            Maximum airmass of the target. `None` indicates no limit.
-
-        min : float or `None`
-            Minimum airmass of the target. `None` indicates no limit.
-
-        Examples
-        --------
-        To create a constraint that requires the airmass be "better than 2",
-        i.e. at a higher altitude than airmass=2::
-
-            AirmassConstraint(2)
-        """
+    def __init__(self, max=None, min=0):
         self.min = min
         self.max = max
 

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -185,7 +185,7 @@ class AirmassConstraint(AltitudeConstraint):
 
         AirmassConstraint(2)
     """
-    def __init__(self, max=None, min=0):
+    def __init__(self, max=None, min=1):
         self.min = min
         self.max = max
 
@@ -193,11 +193,11 @@ class AirmassConstraint(AltitudeConstraint):
         cached_altaz = _get_altaz(times, observer, targets)
         altaz = cached_altaz['altaz']
         if self.min is None and self.max is not None:
-            mask = altaz.secz < self.max
+            mask = altaz.secz <= self.max
         elif self.max is None and self.min is not None:
-            mask = self.min < altaz.secz
+            mask = self.min <= altaz.secz
         elif self.min is not None and self.max is not None:
-            mask = (self.min < altaz.secz) & (altaz.secz < self.max)
+            mask = (self.min <= altaz.secz) & (altaz.secz <= self.max)
         else:
             raise ValueError("No max and/or min specified in "
                              "AirmassConstraint.")

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -131,10 +131,10 @@ class AltitudeConstraint(Constraint):
         Parameters
         ----------
         min : `~astropy.units.Quantity` or `None`
-            Minimum altitude of the target. `None` indicates no limit.
+            Minimum altitude of the target (inclusive). `None` indicates no limit.
 
         max : `~astropy.units.Quantity` or `None`
-            Maximum altitude of the target. `None` indicates no limit.
+            Maximum altitude of the target (inclusive). `None` indicates no limit.
         """
         if min is None:
             self.min = 0*u.deg
@@ -171,12 +171,12 @@ class AirmassConstraint(AltitudeConstraint):
     Parameters
     ----------
     max : float or `None`
-        Maximum airmass of the target. `None` indicates no limit.
+        Maximum airmass of the target (inclusive). `None` indicates no limit.
 
     min : float or `None`
-        Minimum airmass of the target. `None` indicates no limit.  Note that in
-        the `None` case, this will mean *negative* airmasses (below the horizon)
-        are accepted.
+        Minimum airmass of the target (inclusive). `None` indicates no limit.
+        Note that in the `None` case, this will mean *negative* airmasses (below
+        the horizon) are accepted.
 
     Examples
     --------
@@ -214,14 +214,13 @@ class AtNightConstraint(Constraint):
         Parameters
         ----------
         max_solar_altitude : `~astropy.units.Quantity`
-            Define "night" as when the sun is below ``max_solar_altitude``.
-            Default is zero degrees altitude.
-
+            The altitude of the sun below which it is considered to be "night"
+            (inclusive).
         force_pressure_zero : bool (optional)
             Force the pressure to zero for solar altitude calculations. This
             avoids errors in the altitude of the Sun that can occur when the
             Sun is below the horizon and the corrections for atmospheric
-            refraction return nonsense values. Default is `True`.
+            refraction return nonsense values.
         """
         self.max_solar_altitude = max_solar_altitude
         self.force_pressure_zero = force_pressure_zero
@@ -289,11 +288,11 @@ class SunSeparationConstraint(Constraint):
         Parameters
         ----------
         min : `~astropy.units.Quantity` or `None` (optional)
-            Minimum acceptable separation between Sun and target. `None`
-            indicates no limit.
+            Minimum acceptable separation between Sun and target (inclusive).
+            `None` indicates no limit.
         max : `~astropy.units.Quantity` or `None` (optional)
-            Minimum acceptable separation between Sun and target. `None`
-            indicates no limit.
+            Minimum acceptable separation between Sun and target (inclusive).
+            `None` indicates no limit.
         """
         self.min = min
         self.max = max
@@ -326,11 +325,11 @@ class MoonSeparationConstraint(Constraint):
         Parameters
         ----------
         min : `~astropy.units.Quantity` or `None` (optional)
-            Minimum acceptable separation between moon and target. `None`
-            indicates no limit.
+            Minimum acceptable separation between moon and target (inclusive).
+            `None` indicates no limit.
         max : `~astropy.units.Quantity` or `None` (optional)
-            Minimum acceptable separation between moon and target. `None`
-            indicates no limit.
+            Minimum acceptable separation between moon and target (inclusive).
+            `None` indicates no limit.
         """
         self.min = min
         self.max = max
@@ -371,11 +370,11 @@ class MoonIlluminationConstraint(Constraint):
         Parameters
         ----------
         min : float or `None` (optional)
-            Minimum acceptable fractional illumination. `None` indicates no
-            limit.
+            Minimum acceptable fractional illumination (inclusive). `None`
+            indicates no limit.
         max : float or `None` (optional)
-            Maximum acceptable fractional illumination. `None` indicates no
-            limit.
+            Maximum acceptable fractional illumination (inclusive). `None`
+            indicates no limit.
         """
         self.min = min
         self.max = max
@@ -405,10 +404,10 @@ class LocalTimeConstraint(Constraint):
         Parameters
         ----------
         min : `~datetime.time`
-            Earliest local time. `None` indicates no limit.
+            Earliest local time (inclusive). `None` indicates no limit.
 
         max : `~datetime.time`
-            Latest local time. `None` indicates no limit.
+            Latest local time (inclusive). `None` indicates no limit.
 
         Examples
         --------

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -149,8 +149,8 @@ class AltitudeConstraint(Constraint):
 
         cached_altaz = _get_altaz(times, observer, targets)
         altaz = cached_altaz['altaz']
-        lowermask = self.min < altaz.alt
-        uppermask = altaz.alt < self.max
+        lowermask = self.min <= altaz.alt
+        uppermask = altaz.alt <= self.max
         return lowermask & uppermask
 
 
@@ -276,7 +276,7 @@ class AtNightConstraint(Constraint):
     def compute_constraint(self, times, observer, targets):
         sun_altaz = self._get_solar_altitudes(times, observer, targets)
         solar_altitude = sun_altaz['altitude']
-        mask = solar_altitude < self.max_solar_altitude
+        mask = solar_altitude <= self.max_solar_altitude
         return mask
 
 
@@ -305,12 +305,12 @@ class SunSeparationConstraint(Constraint):
         target_altazs = [observer.altaz(times, coo) for coo in target_coos]
         solar_separation = Angle([sunaltaz.separation(taa) for taa in target_altazs])
         if self.min is None and self.max is not None:
-            mask = self.max > solar_separation
+            mask = self.max >= solar_separation
         elif self.max is None and self.min is not None:
-            mask = self.min < solar_separation
+            mask = self.min <= solar_separation
         elif self.min is not None and self.max is not None:
-            mask = ((self.min < solar_separation) &
-                    (solar_separation < self.max))
+            mask = ((self.min <= solar_separation) &
+                    (solar_separation <= self.max))
         else:
             raise ValueError("No max and/or min specified in "
                              "SunSeparationConstraint.")
@@ -350,12 +350,12 @@ class MoonSeparationConstraint(Constraint):
         # Relevant PR: https://github.com/astropy/astropy/issues/4033
 #        moon_separation = Angle([moon.separation(target) for target in targets])
         if self.min is None and self.max is not None:
-            mask = self.max > moon_separation
+            mask = self.max >= moon_separation
         elif self.max is None and self.min is not None:
-            mask = self.min < moon_separation
+            mask = self.min <= moon_separation
         elif self.min is not None and self.max is not None:
-            mask = ((self.min < moon_separation) &
-                    (moon_separation < self.max))
+            mask = ((self.min <= moon_separation) &
+                    (moon_separation <= self.max))
         else:
             raise ValueError("No max and/or min specified in "
                              "MoonSeparationConstraint.")
@@ -384,12 +384,12 @@ class MoonIlluminationConstraint(Constraint):
         illumination = np.array(moon_illumination(times,
                                                   observer.location))
         if self.min is None and self.max is not None:
-            mask = self.max > illumination
+            mask = self.max >= illumination
         elif self.max is None and self.min is not None:
-            mask = self.min < illumination
+            mask = self.min <= illumination
         elif self.min is not None and self.max is not None:
-            mask = ((self.min < illumination) &
-                    (illumination < self.max))
+            mask = ((self.min <= illumination) &
+                    (illumination <= self.max))
         else:
             raise ValueError("No max and/or min specified in "
                              "MoonSeparationConstraint.")
@@ -462,12 +462,12 @@ class LocalTimeConstraint(Constraint):
 
         # If time limits occur on same day:
         if self.min < self.max:
-            mask = [min_time < t.datetime.time() < max_time for t in times]
+            mask = [min_time <= t.datetime.time() <= max_time for t in times]
 
         # If time boundaries straddle midnight:
         else:
-            mask = [(t.datetime.time() > min_time) or
-                    (t.datetime.time() < max_time) for t in times]
+            mask = [(t.datetime.time() >= min_time) or
+                    (t.datetime.time() <= max_time) for t in times]
 
         return mask
 

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -318,3 +318,19 @@ def test_docs_example():
                                   time_range=time_range)
 
     assert all(observability == [False, False, True, False, False, False])
+
+def test_regression_airmass_141():
+    subaru = Observer.at_site("Subaru")
+    time = Time('2001-1-1 12:00')
+
+    coord = SkyCoord(ra=16*u.hour, dec=20*u.deg)
+
+    assert subaru.altaz(time, coord).alt < 0*u.deg
+    # ok, it's below the horizon, so it *definitely* should fail an airmass
+    # constraint of being above 2.  So both of these should give False:
+    consmax = AirmassConstraint(2)
+    consminmax = AirmassConstraint(2, 1)
+
+    assert not consminmax(subaru, [coord], [time]).ravel()[0]
+    # prior to 141 the above works, but the below FAILS
+    assert not consmax(subaru, [coord], [time]).ravel()[0]

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -61,7 +61,9 @@ def test_observability_table():
     targets = [vega, rigel, polaris]
 
     time_range = Time(['2001-02-03 04:05:06', '2001-02-04 04:05:06'])
-    constraints = [AtNightConstraint(), AirmassConstraint(3)]
+    # note that this uses the AirmassConstraint in None min mode - that means
+    # targets below the horizon will pass the airmass constraint
+    constraints = [AtNightConstraint(), AirmassConstraint(3, None)]
 
     obstab = observability_table(constraints, subaru, targets,
                                  time_range=time_range)
@@ -118,7 +120,8 @@ def test_compare_airmass_constraint_and_observer():
 
         max_airmass = 2
         # Check if each target meets airmass constraint in using Observer
-        always_from_observer = [all([subaru.altaz(time, target).secz < max_airmass
+        always_from_observer = [all([(subaru.altaz(time, target).secz < max_airmass)&
+                                     (subaru.altaz(time, target).secz > 0)
                                      for time in time_grid_from_range(time_range)])
                                 for target in targets]
         # Check if each target meets altitude constraints using


### PR DESCRIPTION
It turns out that ``AirmassConstrain(2)`` will return True for targets that are below the horizon.  While this is correct in the sense that allowing a negative airmass is meeting the requirement of "no minmum", I think it misses the point of the primary use case of wanting things to be at a higher airmass than x, while still being *up*.  So this changes the default value of  ``min`` to be 0 instead of ``None``, which strikes me as more intuitive for the typical use case.

It also adds a regression test to make sure this stays true. 