### PR TITLE
Adding build with numpy pre-release to the travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,11 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev SETUP_CMD='test -V'
 
+        # Try pre-release version of Numpy. This only runs if a pre-release
+        # is available on pypi.
+        - os: linux
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=prerelease SETUP_CMD='test -V'
+
         # Try developer version of Astropy
         - os: linux
           env: PYTHON_VERSION=2.7 ASTROPY_VERSION=dev SETUP_CMD='test -V'


### PR DESCRIPTION
~~and updates astropy-helpers to v1.1.1~~

[Edit]: updates the helpers to v1.2rc1 and closes #162