### PR TITLE
Months observable [#143]

### DIFF
--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -570,7 +570,7 @@ def is_observable(constraints, observer, targets, times=None,
 def months_observable(constraints, observer, targets,
                       time_grid_resolution=0.5*u.hour):
     """
-    During which months is the target observable?
+    During which months are the targets observable?
 
     Parameters
     ----------

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -28,7 +28,7 @@ __all__ = ["AltitudeConstraint", "AirmassConstraint", "AtNightConstraint",
            "is_observable", "is_always_observable", "time_grid_from_range",
            "SunSeparationConstraint", "MoonSeparationConstraint",
            "MoonIlluminationConstraint", "LocalTimeConstraint", "Constraint",
-           "observability_table"]
+           "observability_table", "months_observable"]
 
 
 def _get_altaz(times, observer, targets,
@@ -565,6 +565,73 @@ def is_observable(constraints, observer, targets, times=None,
                            for constraint in constraints]
     contraint_arr = np.logical_and.reduce(applied_constraints)
     return np.any(contraint_arr, axis=1)
+
+
+def months_observable(constraints, observer, targets,
+                      time_grid_resolution=0.5*u.hour):
+    """
+    During which months is the target observable?
+
+    Parameters
+    ----------
+    constraints : list or `~astroplan.constraints.Constraint`
+        Observational constraint(s)
+
+    observer : `~astroplan.Observer`
+        The observer who has constraints ``constraints``
+
+    targets : {list, `~astropy.coordinates.SkyCoord`, `~astroplan.FixedTarget`}
+        Target or list of targets
+
+    times : `~astropy.time.Time` (optional)
+        Array of times on which to test the constraint
+
+    time_range : `~astropy.time.Time` (optional)
+        Lower and upper bounds on time sequence, with spacing
+        ``time_resolution``. This will be passed as the first argument into
+        `~astroplan.time_grid_from_range`.
+
+    time_resolution : `~astropy.units.Quantity` (optional)
+        If ``time_range`` is specified, determine whether constraints are met
+        between test times in ``time_range`` by checking constraint at
+        linearly-spaced times separated by ``time_resolution``. Default is 0.5
+        hours.
+
+    Returns
+    -------
+    observable_months : list
+        List of sets of unique integers representing each month that a target is
+        observable, one set per target. These integers are 1-based so that
+        January maps to 1, February maps to 2, etc.
+
+    To Do
+    -----
+    TODO: This method could be sped up a lot by dropping to the trigonometric
+    altitude calculations.
+    """
+    if not hasattr(constraints, '__len__'):
+        constraints = [constraints]
+
+    # Calculate throughout the year of 2014 so as not to require forward
+    # extrapolation off of the IERS tables
+    time_range = Time(['2014-01-01', '2014-12-31'])
+    times = time_grid_from_range(time_range, time_grid_resolution)
+
+    # TODO: This method could be sped up a lot by dropping to the trigonometric
+    # altitude calculations.
+
+    applied_constraints = [constraint(observer, targets,
+                                      times=times)
+                           for constraint in constraints]
+    contraint_arr = np.logical_and.reduce(applied_constraints)
+
+    months_observable = []
+    for target, observable in zip(targets, contraint_arr):
+        s = set([t.datetime.month for t in times[observable]])
+        months_observable.append(s)
+
+    return months_observable
+
 
 def observability_table(constraints, observer, targets, times=None,
                         time_range=None, time_grid_resolution=0.5*u.hour):

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -16,7 +16,7 @@ from ..constraints import (AltitudeConstraint, AirmassConstraint, AtNightConstra
                            is_observable, is_always_observable, observability_table,
                            time_grid_from_range, SunSeparationConstraint,
                            MoonSeparationConstraint, MoonIlluminationConstraint,
-                           LocalTimeConstraint)
+                           LocalTimeConstraint, months_observable)
 
 try:
     import ephem
@@ -322,6 +322,7 @@ def test_docs_example():
 
     assert all(observability == [False, False, True, False, False, False])
 
+
 def test_regression_airmass_141():
     subaru = Observer.at_site("Subaru")
     time = Time('2001-1-1 12:00')
@@ -337,3 +338,21 @@ def test_regression_airmass_141():
     assert not consminmax(subaru, [coord], [time]).ravel()[0]
     # prior to 141 the above works, but the below FAILS
     assert not consmax(subaru, [coord], [time]).ravel()[0]
+
+
+def test_months_observable():
+    obs = Observer(latitude=0*u.deg, longitude=0*u.deg, elevation=0*u.m)
+
+    coords = [SkyCoord(ra=0*u.hourangle, dec=0*u.deg),
+              SkyCoord(ra=6*u.hourangle, dec=0*u.deg),
+              SkyCoord(ra=12*u.hourangle, dec=0*u.deg),
+              SkyCoord(ra=18*u.hourangle, dec=0*u.deg)]
+    targets = [FixedTarget(coord=coord) for coord in coords]
+    constraints = [AltitudeConstraint(min=80*u.deg),
+                   AtNightConstraint.twilight_astronomical()]
+    months = months_observable(constraints, obs, targets)
+
+    should_be = [set({7, 8, 9, 10, 11, 12}), set({1, 2, 3, 10, 11, 12}),
+                 set({1, 2, 3, 4, 5, 6}), set({4, 5, 6, 7, 8, 9})]
+
+    assert months == should_be

--- a/docs/tutorials/constraints.rst
+++ b/docs/tutorials/constraints.rst
@@ -77,25 +77,30 @@ code below.
     constraints = [AltitudeConstraint(10*u.deg, 80*u.deg),
                    AirmassConstraint(5), AtNightConstraint.twilight_civil()]
 
-This list of constraints can now be applied to our target list to determine
-whether:
+This list of constraints can now be applied to our target list to determine:
 
-* the targets are observable given the constraints at *any* times in the time
-  range, using `~astroplan.is_observable`,
+* whether the targets are observable given the constraints at *any* times in the
+  time range, using `~astroplan.is_observable`,
 
-* the targets are observable given the constraints at *all* times in the time
-  range, using `~astroplan.is_always_observable`::
+* whether the targets are observable given the constraints at *all* times in the
+  time range, using `~astroplan.is_always_observable`
 
-    from astroplan import is_observable, is_always_observable
+* during what months the targets are *ever* observable given the constraints,
+  using `~astroplan.months_observable`::
+
+    from astroplan import is_observable, is_always_observable, months_observable
     # Are targets *ever* observable in the time range?
     ever_observable = is_observable(constraints, subaru, targets, time_range=time_range)
 
     # Are targets *always* observable in the time range?
     always_observable = is_always_observable(constraints, subaru, targets, time_range=time_range)
 
-These two functions will return boolean arrays which tell you whether or not
-each target is observable given your constraints. Let's print these results in
-tabular form:
+    # During what months are the targets ever observable?
+    best_months = months_observable(constraints, subaru, targets)
+
+The `~astroplan.is_observable` and `~astroplan.is_always_observable` functions
+will return boolean arrays which tell you whether or not each target is
+observable given your constraints. Let's print these results in tabular form:
 
     >>> from astropy.table import Table
     >>> import numpy as np


### PR DESCRIPTION
This PR addresses a feature request in #143 from the dotastro conference for a convenience method that returns the months in which targets are observable given constraints. I've made a slow but thorough implementation of this method.  

It computes whether or not the target is observable every half hour of every day for a year, then identifies the months during times that are observable. Ideally this would be the kind of calculation that uses the trigonometric target altitude function rather than our iterative/interpolative method that propagates through `SkyCoord`->`AltAz`, adding extra computation time. But I'll leave that for a future PR.

Here's a demo script showing the functionality: 

```python
from astroplan import (FixedTarget, Observer, months_observable, 
                       AltitudeConstraint, AtNightConstraint)
import astropy.units as u

keck = Observer.at_site('Keck')
constraints = [AltitudeConstraint(min=70*u.deg), 
               AtNightConstraint.twilight_astronomical()]
targets = [FixedTarget.from_name('Vega'), FixedTarget.from_name('Regulus')]

months_observable(constraints, keck, targets)
# Returns: [{4, 5, 6, 7, 8, 9}, {1, 2, 3, 4, 5, 11, 12}]
# (Vega is high in summer, Regulus is high in winter)
```