### PR TITLE
Constraint broadcasting

### DIFF
--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -875,8 +875,8 @@ def months_observable(constraints, observer, targets,
         January maps to 1, February maps to 2, etc.
 
     """
-    #TODO: This method could be sped up a lot by dropping to the trigonometric
-    #altitude calculations.
+    # TODO: This method could be sped up a lot by dropping to the trigonometric
+    # altitude calculations.
     if not hasattr(constraints, '__len__'):
         constraints = [constraints]
 

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -560,9 +560,10 @@ class MoonIlluminationConstraint(Constraint):
                              "MoonSeparationConstraint.")
 
         mask = np.logical_or(moon_alt_mask, mask)
-        mask = np.tile(mask, len(targets))
-        return mask.reshape(len(targets), len(times))
-
+        if targets is not None:
+            mask = np.tile(mask, len(targets))
+            mask = mask.reshape(len(targets), len(times))
+        return mask
 
 class LocalTimeConstraint(Constraint):
     """
@@ -663,7 +664,7 @@ class UtcDateConstraint(Constraint):
         >>> subaru = Observer.at_site("Subaru")
         >>> t1 = Time("2016-03-28T12:00:00")
         >>> t2 = Time("2016-03-30T12:00:00")
-        >>> constraint = UTCDateConstraint(t1,t2)
+        >>> constraint = UtcDateConstraint(t1,t2)
         """
         self.min = min
         self.max = max

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -28,9 +28,8 @@ __all__ = ["AltitudeConstraint", "AirmassConstraint", "AtNightConstraint",
            "is_observable", "is_always_observable", "time_grid_from_range",
            "SunSeparationConstraint", "MoonSeparationConstraint",
            "MoonIlluminationConstraint", "LocalTimeConstraint", "Constraint",
-           "UtcDateConstraint", "PierFlipConstraint",
+           "TimeConstraint", "PierFlipConstraint",
            "observability_table", "months_observable"]
-
 
 
 def _get_altaz(times, observer, targets,
@@ -650,8 +649,14 @@ class LocalTimeConstraint(Constraint):
         return np.atleast_2d(mask)
 
 
-class UtcDateConstraint(Constraint):
-    """Constrain the observing time to be within UTC datetime limits"""
+class TimeConstraint(Constraint):
+    """Constrain the observing time to be within certain time limits.
+
+    An example use case for this class would be to associate an acceptable
+    time range with a specific observing block. This can be useful if not
+    all observing blocks are valid over the time limits used in calls
+    to `is_observable` or `is_always_observable`.
+    """
     def __init__(self, min=None, max=None):
         """
         Parameters
@@ -665,7 +670,7 @@ class UtcDateConstraint(Constraint):
         Examples
         --------
         Constrain the observations to targets that are observable between
-        23:50 and 04:08 UTC:
+        2016-03-28 and 2016-03-30:
 
         >>> from astroplan import Observer
         >>> from astropy.time import Time
@@ -673,7 +678,7 @@ class UtcDateConstraint(Constraint):
         >>> subaru = Observer.at_site("Subaru")
         >>> t1 = Time("2016-03-28T12:00:00")
         >>> t2 = Time("2016-03-30T12:00:00")
-        >>> constraint = UtcDateConstraint(t1,t2)
+        >>> constraint = TimeConstraint(t1,t2)
         """
         self.min = min
         self.max = max

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -355,7 +355,7 @@ class SunSeparationConstraint(Constraint):
     def compute_constraint(self, times, observer, targets):
         sunaltaz = observer.altaz(times, get_sun(times))
         target_coos = [target.coord if hasattr(target, 'coord') else target
-                   for target in targets]
+                       for target in targets]
         target_altazs = [observer.altaz(times, coo) for coo in target_coos]
         solar_separation = Angle([sunaltaz.separation(taa) for taa in target_altazs])
         if self.min is None and self.max is not None:
@@ -415,10 +415,6 @@ class MoonSeparationConstraint(Constraint):
                 sep = [moon_coord.separation(target) for target in targets]
                 moon_separation.append(sep)
             moon_separation = Angle(moon_separation).T
-
-        # The line below should have worked, but needs a workaround.
-        # TODO: once bug has been fixed, replace workaround with simpler version.
-        # Relevant PR: https://github.com/astropy/astropy/issues/4033
 
         if self.min is None and self.max is not None:
             mask = self.max >= moon_separation

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -28,7 +28,7 @@ __all__ = ["AltitudeConstraint", "AirmassConstraint", "AtNightConstraint",
            "is_observable", "is_always_observable", "time_grid_from_range",
            "SunSeparationConstraint", "MoonSeparationConstraint",
            "MoonIlluminationConstraint", "LocalTimeConstraint", "Constraint",
-           "TimeConstraint", "PierFlipConstraint",
+           "TimeConstraint", "MeridianTransitConstraint",
            "observability_table", "months_observable"]
 
 
@@ -706,9 +706,9 @@ class TimeConstraint(Constraint):
         return np.atleast_2d(mask)
 
 
-class PierFlipConstraint(Constraint):
+class MeridianTransitConstraint(Constraint):
     """
-    Constrain the target so that a pier flip is not about to occur.
+    Constrain the target so that a meridian transit is not about to occur.
 
     For German equatorial mounts, observing as the object transits the
     meridian requires breaking observations whilst the telescope

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -1489,7 +1489,11 @@ class Observer(object):
                 altaz_frame = AltAz(location=self.location, obstime=t)
                 moon_coord = get_moon(t, location=self.location, ephemeris=ephemeris).transform_to(altaz_frame)
                 moon_coords.append(moon_coord)
-            return moon_coords
+            obstime = [coord.obstime for coord in moon_coords]
+            alts = u.Quantity([coord.alt for coord in moon_coords])
+            azs = u.Quantity([coord.az for coord in moon_coords])
+            dists = u.Quantity([coord.distance for coord in moon_coords])
+            return SkyCoord(AltAz(azs, alts, dists, obstime=obstime,location=self.location))
 
     @u.quantity_input(horizon=u.deg)
     def target_is_up(self, time, target, horizon=0*u.degree, return_altaz=False):

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -364,7 +364,6 @@ constraint_tests = [
 
 
 @pytest.mark.parametrize('constraint', constraint_tests)
-@pytest.mark.skipif('not HAS_PYEPHEM')
 def test_regression_shapes(constraint):
     times = Time(["2015-08-28 03:30", "2015-09-05 10:30", "2015-09-15 18:35"])
     targets = [FixedTarget(SkyCoord(350.7*u.deg, 18.4*u.deg)),

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -15,7 +15,7 @@ from ..constraints import (AltitudeConstraint, AirmassConstraint, AtNightConstra
                            is_observable, is_always_observable, observability_table,
                            time_grid_from_range, SunSeparationConstraint,
                            MoonSeparationConstraint, MoonIlluminationConstraint,
-                           UtcDateConstraint, PierFlipConstraint,
+                           TimeConstraint, PierFlipConstraint,
                            LocalTimeConstraint, months_observable)
 
 APY_LT104 = not minversion('astropy','1.0.4')
@@ -359,7 +359,7 @@ constraint_tests = [
     SunSeparationConstraint(min=90*u.deg),
     MoonSeparationConstraint(min=20*u.deg),
     LocalTimeConstraint(min=dt.time(23, 50), max=dt.time(4, 8)),
-    UtcDateConstraint(*Time(["2015-08-28 03:30", "2015-09-05 10:30"])),
+    TimeConstraint(*Time(["2015-08-28 03:30", "2015-09-05 10:30"])),
     PierFlipConstraint(1000*u.s)
 ]
 

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -15,8 +15,7 @@ from ..constraints import (AltitudeConstraint, AirmassConstraint, AtNightConstra
                            is_observable, is_always_observable, observability_table,
                            time_grid_from_range, SunSeparationConstraint,
                            MoonSeparationConstraint, MoonIlluminationConstraint,
-                           TimeConstraint, MeridianTransitConstraint,
-                           LocalTimeConstraint, months_observable)
+                           TimeConstraint, LocalTimeConstraint, months_observable)
 
 APY_LT104 = not minversion('astropy','1.0.4')
 
@@ -360,8 +359,7 @@ constraint_tests = [
     SunSeparationConstraint(min=90*u.deg),
     MoonSeparationConstraint(min=20*u.deg),
     LocalTimeConstraint(min=dt.time(23, 50), max=dt.time(4, 8)),
-    TimeConstraint(*Time(["2015-08-28 03:30", "2015-09-05 10:30"])),
-    MeridianTransitConstraint(1000*u.s)
+    TimeConstraint(*Time(["2015-08-28 03:30", "2015-09-05 10:30"]))
 ]
 
 

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -15,7 +15,7 @@ from ..constraints import (AltitudeConstraint, AirmassConstraint, AtNightConstra
                            is_observable, is_always_observable, observability_table,
                            time_grid_from_range, SunSeparationConstraint,
                            MoonSeparationConstraint, MoonIlluminationConstraint,
-                           TimeConstraint, PierFlipConstraint,
+                           TimeConstraint, MeridianTransitConstraint,
                            LocalTimeConstraint, months_observable)
 
 APY_LT104 = not minversion('astropy','1.0.4')
@@ -360,7 +360,7 @@ constraint_tests = [
     MoonSeparationConstraint(min=20*u.deg),
     LocalTimeConstraint(min=dt.time(23, 50), max=dt.time(4, 8)),
     TimeConstraint(*Time(["2015-08-28 03:30", "2015-09-05 10:30"])),
-    PierFlipConstraint(1000*u.s)
+    MeridianTransitConstraint(1000*u.s)
 ]
 
 @pytest.mark.parametrize('constraint', constraint_tests)

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -364,6 +364,7 @@ constraint_tests = [
 ]
 
 @pytest.mark.parametrize('constraint', constraint_tests)
+@pytest.mark.skipif('not HAS_PYEPHEM')
 def test_regression_shapes(constraint):
     times = Time(["2015-08-28 03:30", "2015-09-05 10:30", "2015-09-15 18:35"])
     targets = [FixedTarget(SkyCoord(350.7*u.deg, 18.4*u.deg)),

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -126,6 +126,7 @@ def test_compare_airmass_constraint_and_observer():
                                                       time_range=time_range)
         assert all(always_from_observer == always_from_constraint)
 
+
 # in astropy before v1.0.4, a recursion error is triggered by this test
 @pytest.mark.skipif('APY_LT104')
 def test_sun_separation():
@@ -363,6 +364,7 @@ constraint_tests = [
     MeridianTransitConstraint(1000*u.s)
 ]
 
+
 @pytest.mark.parametrize('constraint', constraint_tests)
 @pytest.mark.skipif('not HAS_PYEPHEM')
 def test_regression_shapes(constraint):
@@ -375,4 +377,3 @@ def test_regression_shapes(constraint):
     assert constraint(lapalma, [targets[0]], times).shape == (1, 3)
     assert constraint(lapalma, [targets[0]], times[0]).shape == (1, 1)
     assert constraint(lapalma, targets, times[0]).shape == (2, 1)
-

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -26,10 +26,11 @@ rigel = FixedTarget(coord=SkyCoord(ra=78.63446707*u.deg, dec=8.20163837*u.deg),
 polaris = FixedTarget(coord=SkyCoord(ra=37.95456067*u.deg,
                                      dec=89.26410897*u.deg), name="Polaris")
 
+
 def test_at_night_basic():
     subaru = Observer.at_site("Subaru")
-    time_ranges = [Time(['2001-02-03 04:05:06', '2001-02-04 04:05:06']), # 1 day
-                   Time(['2007-08-09 10:11:12', '2007-08-09 11:11:12'])] # 1 hr
+    time_ranges = [Time(['2001-02-03 04:05:06', '2001-02-04 04:05:06']),  # 1 day
+                   Time(['2007-08-09 10:11:12', '2007-08-09 11:11:12'])]  # 1 hr
     targets = [vega, rigel, polaris]
     for time_range in time_ranges:
         # Calculate constraint using methods on astroplan.Observer:
@@ -49,8 +50,8 @@ def test_at_night_basic():
 
 def test_observability_table():
     subaru = Observer.at_site("Subaru")
-    time_ranges = [Time(['2001-02-03 04:05:06', '2001-02-04 04:05:06']), # 1 day
-                   Time(['2007-08-09 10:11:12', '2007-08-09 11:11:12'])] # 1 hr
+    time_ranges = [Time(['2001-02-03 04:05:06', '2001-02-04 04:05:06']),  # 1 day
+                   Time(['2007-08-09 10:11:12', '2007-08-09 11:11:12'])]  # 1 hr
     targets = [vega, rigel, polaris]
 
     time_range = Time(['2001-02-03 04:05:06', '2001-02-04 04:05:06'])
@@ -72,7 +73,7 @@ def test_observability_table():
     np.testing.assert_allclose(obstab['fraction of time observable'],
                                np.array([21, 22, 15])/48)
 
-    #now compare to is_observable and is_always_observable
+    # now compare to is_observable and is_always_observable
     is_obs = is_observable(constraints, subaru, targets, time_range=time_range)
     np.testing.assert_allclose(obstab['ever observable'], is_obs)
     all_obs = is_always_observable(constraints, subaru, targets,
@@ -124,7 +125,7 @@ def test_compare_airmass_constraint_and_observer():
                                                       time_range=time_range)
         assert all(always_from_observer == always_from_constraint)
 
-#in astropy before v1.0.4, a recursion error is triggered by this test
+# in astropy before v1.0.4, a recursion error is triggered by this test
 @pytest.mark.skipif('APY_LT104')
 def test_sun_separation():
     time = Time('2003-04-05 06:07:08')
@@ -167,7 +168,6 @@ def test_moon_separation():
     print(is_constraint_met)
     assert np.all(is_constraint_met == [[False], [True], [False]])
 
-
     constraint = MoonSeparationConstraint(max=10*u.deg)
     is_constraint_met = constraint(apo, [one_deg_away, five_deg_away,
                                          twenty_deg_away], times=time)
@@ -180,36 +180,38 @@ def test_moon_separation():
 
 
 def test_moon_illumination():
-    times = Time(["2015-08-29 18:35", "2015-09-05 18:35", "2015-09-15 18:35"])
+    times = Time(["2015-08-28 03:30", "2015-09-05 10:30", "2015-09-15 18:35"])
     lco = Observer.at_site("LCO")
     # At these times, moon illuminations are:
-    # [ 0.99946328  0.46867661  0.05379006]
+    # [ 0.9600664 ,  0.49766145,  0.05427445]
+    # and altitudes are:
+    # [ 73.53496408, 42.93207952, 66.46854598] deg
 
     constraint = MoonIlluminationConstraint(min=0.2, max=0.8)
-    is_constraint_met = [constraint(lco, None, times=time) for time in times]
+    is_constraint_met = constraint(lco, None, times=times)
     assert np.all(is_constraint_met == [False, True, False])
 
     constraint = MoonIlluminationConstraint(min=0.2)
-    is_constraint_met = [constraint(lco, None, times=time) for time in times]
+    is_constraint_met = constraint(lco, None, times=times)
     assert np.all(is_constraint_met == [True, True, False])
 
     constraint = MoonIlluminationConstraint(max=0.8)
-    is_constraint_met = [constraint(lco, None, times=time) for time in times]
+    is_constraint_met = constraint(lco, None, times=times)
     assert np.all(is_constraint_met == [False, True, True])
 
 
 def test_local_time_constraint_utc():
     time = Time('2001-02-03 04:05:06')
     subaru = Observer.at_site("Subaru")
-    constraint = LocalTimeConstraint(min=dt.time(23,50), max=dt.time(4,8))
+    constraint = LocalTimeConstraint(min=dt.time(23, 50), max=dt.time(4, 8))
     is_constraint_met = constraint(subaru, None, times=time)
     assert is_constraint_met == [True]
 
-    constraint = LocalTimeConstraint(min=dt.time(0,2), max=dt.time(4,3))
+    constraint = LocalTimeConstraint(min=dt.time(0, 2), max=dt.time(4, 3))
     is_constraint_met = constraint(subaru, None, times=time)
     assert is_constraint_met == [False]
 
-    constraint = LocalTimeConstraint(min=dt.time(3,8), max=dt.time(5,35))
+    constraint = LocalTimeConstraint(min=dt.time(3, 8), max=dt.time(5, 35))
     is_constraint_met = constraint(subaru, None, times=time)
     assert is_constraint_met == [True]
 
@@ -218,15 +220,15 @@ def test_local_time_constraint_hawaii_tz():
     # Define timezone in Observer.timezone
     time = Time('2001-02-03 04:05:06')
     subaru = Observer.at_site("Subaru", timezone="US/Hawaii")
-    constraint = LocalTimeConstraint(min=dt.time(23,50), max=dt.time(4,8))
+    constraint = LocalTimeConstraint(min=dt.time(23, 50), max=dt.time(4, 8))
     is_constraint_met = constraint(subaru, None, times=time)
     assert is_constraint_met == [True]
 
-    constraint = LocalTimeConstraint(min=dt.time(0,2), max=dt.time(4,3))
+    constraint = LocalTimeConstraint(min=dt.time(0, 2), max=dt.time(4, 3))
     is_constraint_met = constraint(subaru, None, times=time)
     assert is_constraint_met == [False]
 
-    constraint = LocalTimeConstraint(min=dt.time(3,8), max=dt.time(5,35))
+    constraint = LocalTimeConstraint(min=dt.time(3, 8), max=dt.time(5, 35))
     is_constraint_met = constraint(subaru, None, times=time)
     assert is_constraint_met == [True]
 

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -271,7 +271,11 @@ class EarthLocation_mock(EarthLocation):
                                            31.963333333333342*u.deg,
                                            2120*u.m)
 
+        lapalma = EarthLocation.from_geodetic(-17.879999*u.deg,
+                                              28.758333*u.deg,
+                                              2327*u.m)
+
         observatories = dict(lco=lco, subaru=subaru, aao=aao, vbo=vbo, apo=apo,
-                             keck=keck, kpno=kpno)
+                             keck=keck, kpno=kpno, lapalma=lapalma)
 
         return observatories[string.lower()]

--- a/docs/tutorials/constraints.rst
+++ b/docs/tutorials/constraints.rst
@@ -234,9 +234,9 @@ be within some angular separation from Vega – we'll call it
   a target could have from Vega.
 
 * We'll also define a method ``compute_constraints`` which takes three
-  arguments: an array of times to test, an `~astroplan.Observer` object, and
-  one or a list of `~astroplan.FixedTarget` objects. ``compute_constraints``
-  will return a matrix of booleans that describe whether or not each target
+  arguments: an array of M times to test, an `~astroplan.Observer` object, and
+  a list of N `~astroplan.FixedTarget` objects. ``compute_constraints``
+  will return a (N, M) shaped matrix of booleans that describe whether or not each target
   meets the constraints.  The super class `~astroplan.Constraint` has a
   ``__call__`` method which will run your custom class's
   ``compute_constraints`` method when you check if a target is observable
@@ -291,9 +291,13 @@ Here's our ``VegaSeparationConstraint`` implementation::
                 raise ValueError("No max and/or min specified in "
                                  "VegaSeparationConstraint.")
 
+
             # Return an array that is True where the target is observable and
             # False where it is not
-            return mask
+            # Must have shape (len(targets), len(times))
+
+            # currently mask has shape (len(targets), 1)
+            return np.tile(mask, len(times))
 
 Then as in the earlier example, we can call our constraint::
 


### PR DESCRIPTION
If I have understood the ```is_observable``` and ```is_always_observable``` routines correctly, then the ```compute_constraint``` function of a constraint should always return an array with shape ```(targets, times)```.

Presently, this is not true, with different constraints returning arrays of different shapes depending on what the shapes of the ```targets``` and ```times``` inputs. This makes the ```is_observable``` and ```is_always_observable``` routines fail when multiple ```targets``` and ```times``` are supplied and the list of constraints include constraints that return inconsistent shapes.

This PR fixes this by ensuring that all constraints return the correct shaped array. I've also added a test for this, but it is not ideal since it won't catch similar bugs in any future ```Constraints``` which are added.

Other changes included in this PR, which may be more properly factored out into separate PRs are:

- make the Moon illumination constraint return ```True``` if the moon has set. Even at full moon, the R-band night sky brightness is >21 if the moon has set (see [here](https://confluence.lsstcorp.org/display/SIM/Sky+Brightness+Observations)), so it doesn't make sense for an illumination constraint not to care if the moon is up

- added constraints on UTC date and a constraint to avoid meridian transits (which is very useful for observers with a German Equatorial Mounted telescope). 

- reverted the workaround which had been put in place because the ```separation``` method of ```SkyCoord``` objects has a bug, which is now fixed.