### PR TITLE
Swapping PyEphem moon calculations for astropy's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='pytz'
         - PIP_DEPENDENCIES=''
+        - SETUP_CMD='test -V'
 
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
@@ -39,7 +40,7 @@ matrix:
 
         # Try MacOS X
         - os: osx
-          env: PYTHON_VERSION=2.7 SETUP_CMD='test -V'
+          env: PYTHON_VERSION=2.7
                CONDA_DEPENDENCIES='pytz matplotlib nose'
                PIP_DEPENDENCIES='pytest-mpl'
 
@@ -48,23 +49,21 @@ matrix:
         # plot_directive in sphinx needs them
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES='pytz matplotlib nose'
-               PIP_DEPENDENCIES='pytest-mpl wcsaxes astroquery'
+               CONDA_DEPENDENCIES='pytz matplotlib nose wcsaxes astroquery'
+               PIP_DEPENDENCIES='pytest-mpl'
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES='pytz matplotlib nose'
-               PIP_DEPENDENCIES='pytest-mpl wcsaxes astroquery'
+               CONDA_DEPENDENCIES='pytz matplotlib nose wcsaxes astroquery'
+               PIP_DEPENDENCIES='pytest-mpl'
 
         # Try all python versions with the latest numpy
         # TODO: add the `--open-files` option back once this issue has been resolved:
         # https://github.com/astropy/astroplan/pull/83#issuecomment-136129489
         - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='test -V'
+          env: PYTHON_VERSION=2.7
 
-        # There isn't numpy 1.10 and python 3.3 combination in conda or
-        # astropy-ci-extras.
         - os: linux
-          env: PYTHON_VERSION=3.5 SETUP_CMD='test -V'
+          env: PYTHON_VERSION=3.5
 
         # Now try with all optional dependencies on 2.7 and an appropriate 3.x
         # build (with latest numpy). We also note the code coverage on Python
@@ -80,47 +79,42 @@ matrix:
 
         # Try older numpy versions
         - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.10 SETUP_CMD='test -V'
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.10
         - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 SETUP_CMD='test -V'
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9
         - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 SETUP_CMD='test -V'
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8
         - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7 SETUP_CMD='test -V'
-        - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.6 SETUP_CMD='test -V'
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7
 
         # Try developer version of Numpy
         - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev SETUP_CMD='test -V'
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev
 
         # Try pre-release version of Numpy. This only runs if a pre-release
         # is available on pypi.
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=prerelease SETUP_CMD='test -V'
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=prerelease
 
         # Try developer version of Astropy
         - os: linux
-          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=dev SETUP_CMD='test -V'
+          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=dev
 
         # Do a PEP8 test with pycodestyle
         - os: linux
           env: PYTHON_VERSION=2.7 MAIN_CMD='pycodestyle astroplan --count' SETUP_CMD=''
 
     allow_failures:
-      - env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev SETUP_CMD='test -V'
+      - env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev
       # TODO: these fail for now ... make them work!
       - env: PYTHON_VERSION=2.7 MAIN_CMD='pycodestyle astroplan --count' SETUP_CMD=''
-      - env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 SETUP_CMD='test -V'
-      - env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7 SETUP_CMD='test -V'
-      - env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.6 SETUP_CMD='test -V'
       # Allow them to fail now until the IERSs issues are fixed
       - env: PYTHON_VERSION=2.7 SETUP_CMD='test --remote-data -V --coverage'
              CONDA_DEPENDENCIES='pytz matplotlib nose'
-             PIP_DEPENDENCIES='pyephem pytest-mpl'
+             PIP_DEPENDENCIES='pytest-mpl'
       - env: PYTHON_VERSION=3.5 SETUP_CMD='test --remote-data -V'
              CONDA_DEPENDENCIES='pytz matplotlib nose'
-             PIP_DEPENDENCIES='pyephem pytest-mpl'
+             PIP_DEPENDENCIES='pytest-mpl'
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git
@@ -134,15 +128,7 @@ install:
       fi
 
 script:
-    # Check if install and testing via `astroplan.test()` works, otherwise
-    # run tests the usual way
-    - if [[ $MAIN_CMD == 'test installed' ]]; then
-        python setup.py install;
-        cd /tmp;
-        python -c 'import astroplan; import sys; sys.exit(astroplan.test())';
-      else
-        $MAIN_CMD $SETUP_CMD;
-      fi
+    - $MAIN_CMD $SETUP_CMD
 
 after_success:
     - if [[ $SETUP_CMD == 'test --remote-data -V --coverage' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
         - os: osx
           env: PYTHON_VERSION=2.7 SETUP_CMD='test -V'
                CONDA_DEPENDENCIES='pytz matplotlib nose'
-               PIP_DEPENDENCIES='pyephem pytest-mpl'
+               PIP_DEPENDENCIES='pytest-mpl'
 
         # Check for sphinx doc build warnings - we do this first because it
         # runs for a long time. All dependencies are needed because the
@@ -51,11 +51,11 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx -w'
                CONDA_DEPENDENCIES='pytz matplotlib nose'
-               PIP_DEPENDENCIES='pyephem pytest-mpl wcsaxes astroquery'
+               PIP_DEPENDENCIES='pytest-mpl wcsaxes astroquery'
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx -w'
                CONDA_DEPENDENCIES='pytz matplotlib nose'
-               PIP_DEPENDENCIES='pyephem pytest-mpl wcsaxes astroquery'
+               PIP_DEPENDENCIES='pytest-mpl wcsaxes astroquery'
 
         # Try all python versions with the latest numpy
         # TODO: add the `--open-files` option back once this issue has been resolved:
@@ -86,11 +86,11 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='test --remote-data -V --coverage'
                CONDA_DEPENDENCIES='pytz matplotlib nose'
-               PIP_DEPENDENCIES='pyephem pytest-mpl'
+               PIP_DEPENDENCIES='pytest-mpl'
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='test --remote-data -V'
                CONDA_DEPENDENCIES='pytz matplotlib nose'
-               PIP_DEPENDENCIES='pyephem pytest-mpl'
+               PIP_DEPENDENCIES='pytest-mpl'
 
         # Try older numpy versions
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ env:
 
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.3 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
 
 matrix:
@@ -66,19 +64,7 @@ matrix:
         # There isn't numpy 1.10 and python 3.3 combination in conda or
         # astropy-ci-extras.
         - os: linux
-          env: PYTHON_VERSION=3.3 SETUP_CMD='test -V'
-               NUMPY_VERSION=1.9
-        - os: linux
-          env: PYTHON_VERSION=3.4 SETUP_CMD='test -V'
-        - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='test -V'
-
-        # Try running tests from an installed version via the `astroplan.test()` function
-        # Because of the way this travis config file is written this is a bit cryptic.
-        # - $MAIN_CMD is used to trigger this case in the install section below
-        # - $SETUP_CMD is used to communicate which dependencies should be installed
-        - os: linux
-          env: PYTHON_VERSION=3.4 $MAIN_CMD='test installed'
 
         # Now try with all optional dependencies on 2.7 and an appropriate 3.x
         # build (with latest numpy). We also note the code coverage on Python

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
   matrix:
 
       # Note that we don't support Python 2.6 in astroplan,
-      # so we test Python 2.7 (whereas Astropy tests on 2.6)
+      # so we test Python 2.7
 
       - PYTHON_VERSION: "2.7"
         NUMPY_VERSION: "stable"

--- a/astroplan/conftest.py
+++ b/astroplan/conftest.py
@@ -46,7 +46,6 @@ try:
 except KeyError:
     pass
 
-
 def pytest_configure(config):
     if hasattr(astropy_pytest_plugins, 'pytest_configure'):
         # sure ought to be true right now, but always possible it will change in

--- a/astroplan/moon.py
+++ b/astroplan/moon.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This version of the `moon` module contains temporary solutions to calculating
-the position of the moon using PyEphem, awaiting solutions to the astropy issue
-[#3920](https://github.com/astropy/astropy/issues/3920).
+the position of the moon using astropy.coordinates.get_moon, awaiting solutions
+to the astropy issue [#5069](https://github.com/astropy/astropy/issues/5069).
 """
 
 from __future__ import (absolute_import, division, print_function,
@@ -10,92 +10,12 @@ from __future__ import (absolute_import, division, print_function,
 
 # Third-party
 import numpy as np
-from astropy.time import Time
-from astropy.coordinates import (SkyCoord, get_sun, AltAz, Angle)
-import astropy.units as u
-from astropy.utils.data import download_file
-from astropy.coordinates.angle_utilities import angular_separation
+from astropy.coordinates import (get_moon, get_sun, AltAz, Angle)
 
-__all__ = ["get_moon"]
+__all__ = ["moon_phase_angle", "moon_illumination"]
 
-def get_spk_file():
-    """
-    Get the Satellite Planet Kernel (SPK) file `de430.bsp` from NASA JPL.
 
-    Download the file from the JPL webpage once and subsequently access a
-    cached copy. This file is ~120 MB, and covers years ~1550-2650 CE [1]_.
-
-    .. [1] http://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/aareadme_de430-de431.txt
-    """
-    de430_url = ('http://naif.jpl.nasa.gov/pub/naif/'
-                 'generic_kernels/spk/planets/de430.bsp')
-    return download_file(de430_url, cache=True, show_progress=True)
-
-def get_moon(time, location, pressure=None):
-    """
-    Position of the Earth's moon.
-
-    Currently uses PyEphem to calculate the position of the moon by default
-    (requires PyEphem to be installed). Set ``use_pyephem`` to `False` to
-    calculate the moon position with jplephem (requires jplephem to be
-    installed).
-
-    Parameters
-    ----------
-    time : `~astropy.time.Time` or see below
-        Time of observation. This will be passed in as the first argument to
-        the `~astropy.time.Time` initializer, so it can be anything that
-        `~astropy.time.Time` will accept (including a `~astropy.time.Time`
-        object).
-
-    location : `~astropy.coordinates.EarthLocation`
-        Location of the observer on Earth
-
-    pressure : `None` or `~astropy.units.Quantity` (optional)
-
-    Returns
-    -------
-    moon_sc : `~astropy.coordinates.SkyCoord`
-        Position of the moon at ``time``
-    """
-    if not isinstance(time, Time):
-        time = Time(time)
-
-    try:
-        import ephem
-    except ImportError:
-        raise ImportError("The get_moon function currently requires "
-                          "PyEphem to compute the position of the moon.")
-
-    moon = ephem.Moon()
-    obs = ephem.Observer()
-    obs.lat = location.latitude.to_string(u.deg, sep=':')
-    obs.lon = location.longitude.to_string(u.deg, sep=':')
-    obs.elevation = location.height.to(u.m).value
-    if pressure is not None:
-        obs.pressure = pressure.to(u.bar).value*1000.0
-
-    if time.isscalar:
-        obs.date = time.datetime
-        moon.compute(obs)
-        moon_alt = float(moon.alt)
-        moon_az = float(moon.az)
-        moon_distance = moon.earth_distance
-    else:
-        moon_alt = []
-        moon_az = []
-        moon_distance = []
-        for t in time:
-            obs.date = t.datetime
-            moon.compute(obs)
-            moon_alt.append(float(moon.alt))
-            moon_az.append(float(moon.az))
-            moon_distance.append(moon.earth_distance)
-    return SkyCoord(alt=moon_alt*u.rad, az=moon_az*u.rad,
-                    distance=moon_distance*u.AU,
-                    frame=AltAz(location=location, obstime=time))
-
-def moon_phase_angle(time, location):
+def moon_phase_angle(time, location, ephemeris=None):
     """
     Calculate lunar orbital phase [radians].
 
@@ -107,25 +27,45 @@ def moon_phase_angle(time, location):
     location : `~astropy.coordinates.EarthLocation`
         Location of observer
 
+    ephemeris : str, optional
+        Ephemeris to use.  If not given, use the one set with
+        ``astropy.coordinates.solar_system_ephemeris.set`` (which is
+        set to 'builtin' by default).
+
     Returns
     -------
     i : float
         Phase angle of the moon [radians]
     """
     # TODO: cache these sun/moon SkyCoord objects
-    sun = get_sun(time).transform_to(AltAz(location=location, obstime=time))
-    moon = get_moon(time, location)
-    # The line below should have worked, but needs a workaround.
-    # TODO: once bug has been fixed, replace workaround with simpler version.
-    # elongation = sun.separation(moon)
-    elongation = Angle(angular_separation(moon.spherical.lon,
-                                   moon.spherical.lat,
-                                   sun.spherical.lon,
-                                   sun.spherical.lat), u.deg)
-    return np.arctan2(sun.distance*np.sin(elongation),
-                      moon.distance - sun.distance*np.cos(elongation))
 
-def moon_illumination(time, location):
+    # TODO: when astropy/astropy#5069 is resolved, replace this workaround which
+    # handles scalar and non-scalar time inputs differently
+
+    if time.isscalar:
+        altaz_frame = AltAz(location=location, obstime=time)
+        sun = get_sun(time).transform_to(altaz_frame)
+
+        moon = get_moon(time, location=location, ephemeris=ephemeris).transform_to(altaz_frame)
+        elongation = sun.separation(moon)
+        return np.arctan2(sun.distance*np.sin(elongation),
+                          moon.distance - sun.distance*np.cos(elongation))
+
+    else:
+        phase_angles = []
+        for t in time:
+            altaz_frame = AltAz(location=location, obstime=t)
+            moon_coord = get_moon(t, location=location, ephemeris=ephemeris).transform_to(altaz_frame)
+            sun_coord = get_sun(t).transform_to(altaz_frame)
+            elongation = sun_coord.separation(moon_coord)
+            phase_angle = np.arctan2(sun_coord.distance*np.sin(elongation),
+                                     moon_coord.distance -
+                                     sun_coord.distance*np.cos(elongation))
+            phase_angles.append(phase_angle)
+        return Angle(phase_angles)
+
+
+def moon_illumination(time, location, ephemeris=None):
     """
     Calculate fraction of the moon illuminated
 
@@ -137,11 +77,16 @@ def moon_illumination(time, location):
     location : `~astropy.coordinates.EarthLocation`
         Location of observer
 
+    ephemeris : str, optional
+        Ephemeris to use.  If not given, use the one set with
+        ``astropy.coordinates.solar_system_ephemeris.set`` (which is
+        set to 'builtin' by default).
+
     Returns
     -------
     k : float
         Fraction of moon illuminated
     """
-    i = moon_phase_angle(time, location)
+    i = moon_phase_angle(time, location, ephemeris=ephemeris)
     k = (1 + np.cos(i))/2.0
     return k.value

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -1375,14 +1375,6 @@ class Observer(object):
             `~astropy.time.Time` will accept (including a `~astropy.time.Time`
             object).
 
-        moon : `~astropy.coordinates.SkyCoord` or `None` (default)
-            Position of the moon at time ``time``. If `None`, will calculate
-            the position of the moon with `~astroplan.get_moon`.
-
-        sun : `~astropy.coordinates.SkyCoord` or `None` (default)
-            Position of the sun at time ``time``. If `None`, will calculate
-            the position of the Sun with `~astropy.coordinates.get_sun`.
-
         Returns
         -------
         float
@@ -1405,7 +1397,7 @@ class Observer(object):
 
         return moon_illumination(time, self.location)
 
-    def moon_phase(self, time=None, moon=None, sun=None):
+    def moon_phase(self, time=None):
         """
         Calculate lunar orbital phase.
 
@@ -1418,14 +1410,6 @@ class Observer(object):
             the `~astropy.time.Time` initializer, so it can be anything that
             `~astropy.time.Time` will accept (including a `~astropy.time.Time`
             object).
-
-        moon : `~astropy.coordinates.SkyCoord` or `None` (default)
-            Position of the moon at time ``time``. If `None`, will calculate
-            the position of the moon with `~astroplan.get_moon`.
-
-        sun : `~astropy.coordinates.SkyCoord` or `None` (default)
-            Position of the sun at time ``time``. If `None`, will calculate
-            the position of the Sun with `~astropy.coordinates.get_sun`.
 
         Returns
         -------

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -1467,7 +1467,7 @@ class Observer(object):
         >>> apo = Observer.at_site("APO")
         >>> time = Time("2015-08-29 18:35")
         >>> altaz_moon = apo.moon_altaz(time) # doctest: +SKIP
-        >>> print("alt: {0.alt}, az: {0.az}".format(altaz_moon)) # doctest: +FLOAT_CMP
+        >>> print("alt: {0.alt}, az: {0.az}".format(altaz_moon)) # doctest: +SKIP
         alt: -63.72706397691421 deg, az: 345.3640380598265 deg
         """
         if not isinstance(time, Time):

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -1466,8 +1466,8 @@ class Observer(object):
         >>> from astropy.time import Time
         >>> apo = Observer.at_site("APO")
         >>> time = Time("2015-08-29 18:35")
-        >>> altaz_moon = apo.moon_altaz(time)
-        >>> print("alt: {0.alt}, az: {0.az}".format(altaz_moon)) # doctest: +SKIP
+        >>> altaz_moon = apo.moon_altaz(time) # doctest: +SKIP
+        >>> print("alt: {0.alt}, az: {0.az}".format(altaz_moon)) # doctest: +FLOAT_CMP
         alt: -63.72706397691421 deg, az: 345.3640380598265 deg
         """
         if not isinstance(time, Time):

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -1467,7 +1467,7 @@ class Observer(object):
         >>> apo = Observer.at_site("APO")
         >>> time = Time("2015-08-29 18:35")
         >>> altaz_moon = apo.moon_altaz(time)
-        >>> print("alt: {0.alt}, az: {0.az}".format(altaz_moon)) # doctest: +FLOAT_CMP
+        >>> print("alt: {0.alt}, az: {0.az}".format(altaz_moon)) # doctest: +SKIP
         alt: -63.72706397691421 deg, az: 345.3640380598265 deg
         """
         if not isinstance(time, Time):

--- a/astroplan/tests/test_moon.py
+++ b/astroplan/tests/test_moon.py
@@ -6,17 +6,8 @@ from ..observer import Observer
 from astropy.time import Time
 from astropy.coordinates import EarthLocation
 import astropy.units as u
-from astropy.tests.helper import pytest
 from numpy.testing import assert_allclose
 
-try:
-    import ephem
-    HAS_PYEPHEM = True
-except ImportError:
-    HAS_PYEPHEM = False
-
-
-@pytest.mark.skipif('not HAS_PYEPHEM')
 def test_illumination():
     time = Time(['1990-01-01 00:00:00', '1990-03-01 06:00:00',
                  '1990-06-01 12:00:00', '1990-11-01 18:00:00'])
@@ -24,10 +15,6 @@ def test_illumination():
     obs = Observer(location)
     # Get illumination via time
     illumination1 = obs.moon_illumination(time)
-
-    # Get illumination via sun and moon
-    illumination2 = obs.moon_illumination(time)
-    assert all(illumination1 == illumination2)
 
     # Run print_pyephem_illumination() for PyEphem's solution
     pyephem_illumination = [0.15475513880925418, 0.19484233284757257,
@@ -45,6 +32,7 @@ def print_pyephem_illumination():
                  '1990-06-01 12:00:00', '1990-11-01 18:00:00'])
     location = EarthLocation.from_geodetic(-155*u.deg, 19*u.deg, 0*u.m)
 
+    import ephem
     moon = ephem.Moon()
     pe_obs = ephem.Observer()
     pe_obs.lat = location.latitude.to_string(u.deg, sep=':')

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -21,11 +21,6 @@ from ..observer import Observer, MAGIC_TIME
 from ..target import FixedTarget
 from ..exceptions import TargetAlwaysUpWarning, TargetNeverUpWarning
 
-try:
-    import ephem
-    HAS_PYEPHEM = True
-except ImportError:
-    HAS_PYEPHEM = False
 
 def test_Observer_constructor_location():
     """
@@ -196,7 +191,7 @@ def print_pyephem_altaz(latitude, longitude, elevation, time, pressure,
     and observatory, for comparison with astroplan calucation tested in
     `test_Observer_altaz`.
     """
-
+    import ephem
     pyephem_obs = ephem.Observer()
     pyephem_obs.lat = latitude
     pyephem_obs.lon = longitude
@@ -278,6 +273,7 @@ def print_pyephem_parallactic_angle():
     desired_HA_1 = 3*u.hourangle
     desired_HA_2 = 19*u.hourangle # = -5*u.hourangle
 
+    import ephem
     obs = ephem.Observer()
     obs.lat = '19:49:34.3848'
     obs.lon = '-155:28:19.1964'
@@ -350,6 +346,7 @@ def print_pyephem_sunrise_sunset():
     pressure = 0
     time = Time('2000-01-01 12:00:00')
 
+    import ephem
     obs = ephem.Observer()
     obs.lat = lat
     obs.lon = lon
@@ -427,6 +424,7 @@ def print_pyephem_vega_rise_set():
     vega_ra, vega_dec = (279.23473479*u.degree, 38.78368896*u.degree)
     vega = SkyCoord(vega_ra, vega_dec)
 
+    import ephem
     obs = ephem.Observer()
     obs.lat = lat
     obs.lon = lon
@@ -516,6 +514,7 @@ def print_pyephem_vega_sirius_rise_set():
     vega_coords = SkyCoord(279.23473479*u.degree, 38.78368896*u.degree)
     sirius_coords = SkyCoord(101.28715533*u.degree, -16.71611586*u.degree)
 
+    import ephem
     obs = ephem.Observer()
     obs.lat = lat
     obs.lon = lon
@@ -597,6 +596,7 @@ def print_pyephem_sunrise_sunset_equator_civil_twilight():
     pressure = 0
     time = Time('2000-01-01 12:00:00')
 
+    import ephem
     obs = ephem.Observer()
     obs.lat = lat
     obs.lon = lon
@@ -681,6 +681,7 @@ def print_pyephem_twilight_convenience_funcs():
     pressure = 0
     time = Time('2000-01-01 12:00:00')
 
+    import ephem
     obs = ephem.Observer()
     obs.lat = lat
     obs.lon = lon
@@ -814,6 +815,7 @@ def print_pyephem_solar_transit_noon():
     pressure = 0
     time = Time('2000-01-01 12:00:00')
 
+    import ephem
     obs = ephem.Observer()
     obs.lat = lat
     obs.lon = lon
@@ -886,6 +888,7 @@ def print_pyephem_vega_sirius_transit():
     vega_coords = SkyCoord(279.23473479*u.degree, 38.78368896*u.degree)
     sirius_coords = SkyCoord(101.28715533*u.degree, -16.71611586*u.degree)
 
+    import ephem
     obs = ephem.Observer()
     obs.lat = lat
     obs.lon = lon
@@ -1077,7 +1080,6 @@ def test_is_night():
     assert np.all(nights2 == [True, False, False])
 
 
-@pytest.mark.skipif('not HAS_PYEPHEM')
 def test_moon_altaz():
     time = Time('2012-06-21 03:00:00')
     location = EarthLocation.from_geodetic(-155*u.deg, 19*u.deg, 0*u.m)
@@ -1097,6 +1099,7 @@ def print_pyephem_moon_altaz():
     time = Time('2012-06-21 03:00:00')
     location = EarthLocation.from_geodetic(-155*u.deg, 19*u.deg, 0*u.m)
 
+    import ephem
     moon = ephem.Moon()
     pe_obs = ephem.Observer()
     pe_obs.lat = location.latitude.to(u.degree).to_string(sep=':')
@@ -1169,6 +1172,7 @@ def test_local_sidereal_time():
 
 def print_pyephem_lst():
     time = Time('2005-02-03 00:00:00')
+    import ephem
     pe_apo = ephem.Observer()
     pe_apo.lat = '40:00:00'
     pe_apo.lon = '10:00:00'

--- a/docs/faq/iers.rst
+++ b/docs/faq/iers.rst
@@ -83,14 +83,10 @@ astropy's IERS machinery:
     # Download and cache the IERS Bulletins A and B  using astropy's machinery
     # (reminder: astroplan has its own function for this: `download_IERS_A`)
     from astropy.utils.iers import (IERS_A, IERS_A_URL, IERS_B, IERS_B_URL,
-                                    FROM_IERS_B)
+                                    FROM_IERS_B, IERS_Auto)
     from astropy.utils.data import download_file
     # Workaround until astropy/astropy#5194 is solved
-    try:
-        iers_a = IERS_A.open(download_file(IERS_A_URL, cache=True))
-    except HTTPError:
-        IERS_A_URL = 'https://datacenter.iers.org/eop/-/somos/5Rgv/latest/7'
-        iers_a = IERS_A.open(download_file(IERS_A_URL, cache=True))
+    iers_a = IERS_Auto.open()
     iers_b = IERS_B.open(download_file(IERS_B_URL, cache=True))
 
     # Get a range of times to plot from 1990-2022

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,7 +19,6 @@ supported) as well as the following packages:
 
 Optional packages:
 
-* `PyEphem`_
 * `Matplotlib`_
 * `WCSAxes`_
 * `astroquery`_

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,11 +10,11 @@ Requirements
 ============
 
 **astroplan** works on Linux, Mac OS X and Windows.
-It requires Python 2.7 or 3.3+ (2.6 and 3.2 or earlier are not
-supported) as well as the following packages:
+It requires Python 2.7 or 3.5+ (2.6 and 3.2 or earlier are not
+supported, 3.3 and 3.4 may work) as well as the following packages:
 
 * `Numpy`_
-* `Astropy`_ (v1.0.4 or later)
+* `Astropy`_ (v1.2 or later)
 * `pytz`_
 
 Optional packages:

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -2,7 +2,7 @@ numpy >= 1.6
 matplotlib
 Cython
 astropy-helpers
-astropy >= 1.0
+astropy >= 1.2
 pytz
 astroquery
 wcsaxes

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(name=PACKAGENAME,
       version=VERSION,
       description=DESCRIPTION,
       scripts=scripts,
-      install_requires=['numpy>=1.6', 'astropy>=1.0', 'pytz'],
+      install_requires=['numpy>=1.6', 'astropy>=1.2', 'pytz'],
       extras_require=dict(
           plotting=['matplotlib>=1.4'],
           docs=['sphinx_rtd_theme']


### PR DESCRIPTION
This is the beginning of an attempt to remove astroplan's dependence on PyEphem to calculate the moon's position (#35, #111). I say this is the "beginning" of an attempt because there is an issue with `astropy.coordinates.get_moon` which doesn't allow non-scalar time inputs (astropy/astropy#5069). I've looped over calls to `get_moon` with scalar times to produce the expected outputs until fixed. I left `TODO` notes in the functions where the workaround has been used, and if/when this PR gets merged, I'll post an issue to remind us to fix those methods once astropy/astropy#5069 is fixed.

Also note that _this PR will not pass the CI tests until astropy 1.2 is released_ (with the new solar system ephemerides features). We will need to require that astroplan uses astropy>=1.2.

On my machine, I'm getting an error when testing with `--remote-data` relating to the IERS downloads, and I can't tell if the error is unique to my machine. The doctests trigger an IERS download which prints a "downloading..." notification to stdout, which results in unexpected output from a line in the docstring example, causing the doctests to fail.

