### PR TITLE
Constraint docstring tweaks

### DIFF
--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -604,11 +604,9 @@ def months_observable(constraints, observer, targets,
         observable, one set per target. These integers are 1-based so that
         January maps to 1, February maps to 2, etc.
 
-    To Do
-    -----
-    TODO: This method could be sped up a lot by dropping to the trigonometric
-    altitude calculations.
     """
+    #TODO: This method could be sped up a lot by dropping to the trigonometric
+    #altitude calculations.
     if not hasattr(constraints, '__len__'):
         constraints = [constraints]
 

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -474,8 +474,9 @@ class LocalTimeConstraint(Constraint):
 def is_always_observable(constraints, observer, targets, times=None,
                          time_range=None, time_grid_resolution=0.5*u.hour):
     """
-    Are the ``targets`` always observable throughout ``time_range`` given
-    constraints in ``constraints_list`` for ``observer``?
+    A function to determine whether ``targets`` are always observable throughout
+    ``time_range`` given constraints in the ``constraints_list`` for a
+    particular ``observer``.
 
     Parameters
     ----------
@@ -522,8 +523,8 @@ def is_always_observable(constraints, observer, targets, times=None,
 def is_observable(constraints, observer, targets, times=None,
                   time_range=None, time_grid_resolution=0.5*u.hour):
     """
-    Are the ``targets`` observable during ``time_range`` given constraints in
-    ``constraints_list`` for ``observer``?
+    Determines if the ``targets`` are observable during ``time_range`` given
+    constraints in ``constraints_list`` for a particular ``observer``.
 
     Parameters
     ----------
@@ -570,7 +571,8 @@ def is_observable(constraints, observer, targets, times=None,
 def months_observable(constraints, observer, targets,
                       time_grid_resolution=0.5*u.hour):
     """
-    During which months are the targets observable?
+    Determines which month the specified ``targets`` are observable for a
+    specific ``observer``, given the supplied ``constriants``.
 
     Parameters
     ----------


### PR DESCRIPTION
While doing a post-hoc review of #152 (sorry about not doing that sooner, @bmorris3), I noticed that a number of the constraint docstrings were in "question-form".  That's not PEP8 compliant, but more importantly, I think it's a bit confusing, because it's not clear that the goal of the function is to *answer* that question.  So this just re-words those docstrings to be descriptive rather than "question-form".

This also removes a "to do" section that I think @bmorris3 added in #152 - my justification for that is that in my experience "todo's" can live a long time, so it's better to leave them as hints for those perusing the code rather than the documentation... But if there was a particular reason you really wanted that one in there, I can certainly remove that commit.