### PR TITLE
Dark Grey or Bright time constraint

### DIFF
--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -402,7 +402,7 @@ class DarkGreyBrightConstraint(Constraint):
     """
     # TODO: make a new test
     @u.quantity_input(horizon=u.deg)
-    def __init__(self lunar_horizon=90*u.deg, min_moon_illumination=0,
+    def __init__(self, lunar_horizon=90*u.deg, min_moon_illumination=0,
                                                 max_moon_illumination=1):
         '''
         Parameters
@@ -425,8 +425,8 @@ class DarkGreyBrightConstraint(Constraint):
         >>> greytime = DarkGreyBrightConstraint(max_moon_illumination=.5)
         '''
         
-        self.min_illumination = min_max_moon_illumination[0]
-        self.max_illumination = min_max_moon_illumination[1]
+        self.min_illumination = min_moon_illumination
+        self.max_illumination = max_moon_illumination
         self.horizon = lunar_horizon
         
     def _get_lunar_altitudes(self, times, observer, targets):
@@ -436,15 +436,15 @@ class DarkGreyBrightConstraint(Constraint):
         aakey = (tuple(times.jd), 'sun')
 
         if aakey not in observer._altaz_cache:
-            try:
-                # Broadcast the lunar altitudes for the number of targets:
-                altaz = observer.altaz(times, get_moon(times))
-                altitude = altaz.alt
-                altitude.resize(1, len(altitude))
-                altitude = altitude + np.zeros((len(targets), 1))
+            # TODO: make sure this works properly
+            # Broadcast the lunar altitudes for the number of targets:
+            altaz = observer.altaz(times, get_moon(times))
+            altitude = altaz.alt
+            altitude.resize(1, len(altitude))
+            altitude = altitude + np.zeros((len(targets), 1))
 
-                observer._altaz_cache[aakey] = dict(times=times,
-                                                    altitude=altitude)
+            observer._altaz_cache[aakey] = dict(times=times,
+                                                altitude=altitude)
 
         return observer._altaz_cache[aakey]
         

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -402,8 +402,8 @@ class DarkGreyBrightConstraint(Constraint):
     """
     # TODO: make a new test
     @u.quantity_input(horizon=u.deg)
-    def __init__(self, lunar_horizon=90*u.deg, min_moon_illumination=0,
-                                                max_moon_illumination=1):
+    def __init__(self, lunar_horizon=90*u.deg, min_moon_illumination=None,
+                                                max_moon_illumination=None):
         '''
         Parameters
         ----------
@@ -425,8 +425,8 @@ class DarkGreyBrightConstraint(Constraint):
         >>> greytime = DarkGreyBrightConstraint(max_moon_illumination=.5)
         '''
         
-        self.min_illumination = min_moon_illumination
-        self.max_illumination = max_moon_illumination
+        self.min = min_moon_illumination
+        self.max = max_moon_illumination
         self.horizon = lunar_horizon
         
     def _get_lunar_altitudes(self, times, observer, targets):
@@ -438,11 +438,13 @@ class DarkGreyBrightConstraint(Constraint):
         if aakey not in observer._altaz_cache:
             # TODO: make sure this works properly
             # Broadcast the lunar altitudes for the number of targets:
-            altaz = observer.altaz(times, get_moon(times))
+            altaz = observer.altaz(times, get_moon(times, observer.location))
             altitude = altaz.alt
             altitude.resize(1, len(altitude))
-            altitude = altitude + np.zeros((len(targets), 1))
-
+            try:
+                altitude = altitude + np.zeros((len(targets), 1))
+            except TypeError:
+                pass
             observer._altaz_cache[aakey] = dict(times=times,
                                                 altitude=altitude)
 

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -27,7 +27,7 @@ from .target import FixedTarget
 __all__ = ["AltitudeConstraint", "AirmassConstraint", "AtNightConstraint",
            "is_observable", "is_always_observable", "time_grid_from_range",
            "SunSeparationConstraint", "MoonSeparationConstraint",
-           "MoonIlluminationConstraint", "TimeBrightnessConstraint",
+           "MoonIlluminationConstraint", "DarkGreyBrightConstraint",
            "LocalTimeConstraint", "Constraint",
            "observability_table", "months_observable"]
 

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -1520,40 +1520,6 @@ class Observer(object):
                 moon_az.append(float(moon.az))
         return SkyCoord(alt=moon_alt*u.rad, az=moon_az*u.rad,
                         frame=self.altaz(time))
-
-    @u.quantity_input(horizon=u.deg)
-    def is_moon_up(self, time, horizon=0*u.degree):
-        # TODO: add a test 
-        """
-        Is the Moon above the horizion at this ``time``?
-        
-        Parameters
-        ----------
-        time: `~astropy.time.Time` or other (see below)
-            This will be passed in as the first argument to
-            the `~astropy.time.Time` initialiwzer, so it can be anything that
-            `~astropy.time.Time` will accept (including a `~astropy.time.Time`
-            object).
-            
-        horizon : `~astropy.units.Quantity` (optional), default = zero degrees
-            Degrees above/below actual horizon to use
-            for calculating rise/set times (i.e.,
-            -6 deg horizon = civil twilight, etc.)            
-            
-        Returns
-        -------
-        In_sky : boolean
-            True if Moon is above ``horizon`` at ``time``, else False.
-        
-        """
-
-        if not isinstance(time, Time):
-            time = Time(time)
-
-        moon_altaz = self.moon_altaz(time)
-        In_sky = bool(moon_altaz.alt > horizon)
-        
-        return In_sky 
     
     @u.quantity_input(horizon=u.deg)
     def target_is_up(self, time, target, horizon=0*u.degree, return_altaz=False):

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -1522,6 +1522,40 @@ class Observer(object):
                         frame=self.altaz(time))
 
     @u.quantity_input(horizon=u.deg)
+    def is_moon_up(self, time, horizon=0*u.degree):
+        # TODO: add a test 
+        """
+        Is the Moon above the horizion at this ``time``?
+        
+        Parameters
+        ----------
+        time: `~astropy.time.Time` or other (see below)
+            This will be passed in as the first argument to
+            the `~astropy.time.Time` initialiwzer, so it can be anything that
+            `~astropy.time.Time` will accept (including a `~astropy.time.Time`
+            object).
+            
+        horizon : `~astropy.units.Quantity` (optional), default = zero degrees
+            Degrees above/below actual horizon to use
+            for calculating rise/set times (i.e.,
+            -6 deg horizon = civil twilight, etc.)            
+            
+        Returns
+        -------
+        In_sky : boolean
+            True if Moon is above ``horizon`` at ``time``, else False.
+        
+        """
+
+        if not isinstance(time, Time):
+            time = Time(time)
+
+        moon_altaz = self.moon_altaz(time)
+        In_sky = bool(moon_altaz.alt > horizon)
+        
+        return In_sky 
+    
+    @u.quantity_input(horizon=u.deg)
     def target_is_up(self, time, target, horizon=0*u.degree, return_altaz=False):
         """
         Is ``target`` above ``horizon`` at this ``time``?

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -206,7 +206,7 @@ def test_moon_illumination():
     is_constraint_met = [constraint(lco, None, times=time) for time in times]
     assert np.all(is_constraint_met == [False, True, True])
 
-    
+@pytest.mark.skipif('not HAS_PYEPHEM')
 def test_Dark_Grey_Bright():
     darktime = DarkGreyBrightConstraint(lunar_horizon=-5*u.deg) 
     greytime = DarkGreyBrightConstraint(max_moon_illumination=.5)

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -16,7 +16,7 @@ from ..constraints import (AltitudeConstraint, AirmassConstraint, AtNightConstra
                            is_observable, is_always_observable, observability_table,
                            time_grid_from_range, SunSeparationConstraint,
                            MoonSeparationConstraint, MoonIlluminationConstraint,
-                           TimeBrightnessConstraint, LocalTimeConstraint, months_observable)
+                           DarkGreyBrightConstraint, LocalTimeConstraint, months_observable)
 
 try:
     import ephem
@@ -207,48 +207,11 @@ def test_moon_illumination():
     assert np.all(is_constraint_met == [False, True, True])
 
     
-def test_time_brightness_constraint():
-    time = Time('2001-02-03 04:05:06')
-    time_ranges = [Time([time, time+1*u.hour]) + offset
-                       for offset in np.arange(0, 400, 100)*u.day]
-    mro = Observer.at_site('MRO')
-    targets = [vega, rigel, polaris]
+def test_Dark_Grey_Bright():
+    # TODO: write the test
+    pass
     
-    for time_range in time_ranges:
-        #testing whether dark works
-        time = 'dark'
-        always_from_observer = [all([mro.moon_altaz(time).alt <= 0 
-                                     for time in time_grid_from_range(time_range)])
-                                for target in targets]
-        print([[mro.moon_altaz(time).alt for time in time_grid_from_range(time_range)]
-                                for target in targets])
-        always_from_constraint = is_always_observable(TimeBrightnessConstraint(
-                                                            time=time),
-                                                      mro, targets,
-                                                      time_range=time_range)
-        print(always_from_constraint)
-        assert all(always_from_observer == always_from_constraint)
-    # TODO: fix the code below to test when the max is defined
-    ''' The code below relies on things that aren't being called nicely (.spherical)
-    for time_range in time_ranges:
-        #does it work for defined maximum brightness
-        bright_max = 0.7
-        times = time_grid_from_range(time_range)
-        moon = get_moon(times, mro.location, mro.pressure)
-        always_from_observer = [all([mro.moon_altaz(time).alt*moon_illumination(time,mro.location)*
-                                      (1-(Angle(angular_separation(moon.spherical.lon,
-                                                    moon.spherical.lat,
-                                                    target.spherical.lon,
-                                                    target.spherical.lat))/180.))<= 0.7
-                                     for time in times])
-                                for target in targets]
-        always_from_constraint = is_always_observable(TimeBrightnessConstraint(
-                                                            max = bright_max),
-                                                      mro, targets,
-                                                      time_range=time_range)
-        assert all(always_from_observer == always_from_constraint)
-        '''
-        
+    
 def test_local_time_constraint_utc():
     time = Time('2001-02-03 04:05:06')
     subaru = Observer.at_site("Subaru")

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -119,7 +119,7 @@ def test_compare_airmass_constraint_and_observer():
         targets = [vega, rigel, polaris]
 
         max_airmass = 2
-        # Check if each target meets airmass constraint in using Observer
+        # Check if each target meets airmass constraint using Observer
         always_from_observer = [all([(subaru.altaz(time, target).secz < max_airmass)&
                                      (subaru.altaz(time, target).secz > 0)
                                      for time in time_grid_from_range(time_range)])
@@ -208,8 +208,23 @@ def test_moon_illumination():
 
     
 def test_Dark_Grey_Bright():
-    # TODO: write the test
-    pass
+    darktime = DarkGreyBrightConstraint(lunar_horizon=-5*u.deg) 
+    greytime = DarkGreyBrightConstraint(max_moon_illumination=.5)
+    brighttime = DarkGreyBrightConstraint(min_moon_illumination = .5)
+    
+    times = Time(["2015-08-29 18:35", "2015-09-05 18:35", "2015-09-15 18:35"])
+    lco = Observer.at_site("LCO")
+    # At these times, moon illuminations are:
+    # [ 0.99946328  0.46867661  0.05379006]
+    # Moon altitudes are:
+    #[-45:11:59.8996 -31:30:40.556 66:28:06.7655]
+    # TODO: write a test with targets
+    is_darktime_met = darktime(lco, None, times=times)
+    is_greytime_met = greytime(lco, None, times=times)
+    is_brighttime_met = brighttime(lco, None, times=times)
+    assert np.all(is_darktime_met == [True, True, False])
+    assert np.all(is_greytime_met == [False, True, True])
+    assert np.all(is_brighttime_met == [True, False, False])
     
     
 def test_local_time_constraint_utc():


### PR DESCRIPTION
Adding a constraint that allows a user to define dark/grey/bright time using how high above the horizon and how illuminated the moon is. 