### PR TITLE
changed the way ConfigParser is imported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+from configparser import ConfigParser
+conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 


### PR DESCRIPTION
Because python3.5.2 apparently doesn't handle the way configparser was being called, I changed how it is imported. Hopefully this fixes #186.