### PR TITLE
Vectorised constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ docs/_build
 # Pycharm editor project files
 .idea
 
+# VS Studio Code project files
+.vscode
+
 # Packages/installer info
 *.egg
 *.egg-info

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -468,7 +468,7 @@ class AtNightConstraint(Constraint):
             Sun is below the horizon and the corrections for atmospheric
             refraction return nonsense values.
         """
-        self.max_solar_altitude = max_solar_altitude
+        self.max_solar_altitude = self._recast_limits(max_solar_altitude)
         self.force_pressure_zero = force_pressure_zero
 
     @classmethod
@@ -549,8 +549,8 @@ class SunSeparationConstraint(Constraint):
             Minimum acceptable separation between Sun and target (inclusive).
             `None` indicates no limit.
         """
-        self.min = min
-        self.max = max
+        self.min = self._recast_limits(min)
+        self.max = self._recast_limits(max)
 
     def compute_constraint(self, times, observer, targets):
         sunaltaz = observer.altaz(times, get_sun(times), grid=False)

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -15,7 +15,8 @@ import warnings
 # Third-party
 from astropy.time import Time
 import astropy.units as u
-from astropy.coordinates import get_sun, get_moon, Angle, SkyCoord
+from astropy.coordinates import (get_sun, get_moon, Angle, SkyCoord,
+                                 AltAz)
 from astropy import table
 import numpy as np
 

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -172,6 +172,34 @@ def limit(storage_name):
 
     This will ensure that any attempt to set the limit goes through
     a call to recast_limits.
+
+    Examples
+    ---------
+    >>> class MyConstraint(Constraint):
+    ...     # A demo constraint that does nothing
+    ...     min = limit('min')
+    ...     max = limit('max')  # set min and max properties to use limit property factory
+    ...
+    ...     def __init__(self, min=None, max=None):
+    ...             self.min = min
+    ...             self.max = max  # setting self.max goes through _recast_limits
+    ...
+    ...     def compute_constraint(self, times, observer, targets):
+    ...             return np.atleast_2d(True)
+    ...
+    >>>
+    >>> cons = MyConstraint(max=2)
+    >>> cons.max
+    array([[2]])
+    >>> cons.max = 3
+    >>> cons.max.shape
+    (1, 1)
+    >>> cons.max = [3, 2]
+    >>> cons.max
+    array([[3],
+           [2]])
+    >>> cons.max.shape
+    (2, 1)
     """
     def limit_getter(instance):
         return instance.__dict__[storage_name]

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -804,22 +804,22 @@ class LocalTimeConstraint(Constraint):
         if self.min is not None:
             min_time = self.min
         else:
-            min_time = self.min = self._recast_limits(datetime.time(0, 0, 0))
+            min_time = self._recast_limits(datetime.time(0, 0, 0))
 
         if self.max is not None:
             max_time = self.max
         else:
-            max_time = self.max = self._recast_limits(datetime.time(23, 59, 59))
+            max_time = self._recast_limits(datetime.time(23, 59, 59))
 
         # make numpy ufunc to get time from astropy time object
         gettime = np.frompyfunc(lambda x: x.time(), 1, 1)
 
         # If time limits occur on same day:
-        same_day_mask = np.tile(self.min < self.max, len(times))
-        same_day_mask_values = np.logical_and(self.min <= gettime(times.datetime),
-                                              gettime(times.datetime) <= self.max)
-        mask = np.logical_or(gettime(times.datetime) >= self.min,
-                             gettime(times.datetime) <= self.max)
+        same_day_mask = np.tile(min_time < max_time, len(times))
+        same_day_mask_values = np.logical_and(min_time <= gettime(times.datetime),
+                                              gettime(times.datetime) <= max_time)
+        mask = np.logical_or(gettime(times.datetime) >= min_time,
+                             gettime(times.datetime) <= max_time)
         mask[same_day_mask] = same_day_mask_values[same_day_mask]
 
         if targets is not None:

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -414,8 +414,8 @@ class AirmassConstraint(AltitudeConstraint):
     max = limit('max')
 
     def __init__(self, max=None, min=1, boolean_constraint=True):
-        self.min = min
-        self.max = max
+        self.min = self._recast_limits(min)
+        self.max = self._recast_limits(max)
         self.boolean_constraint = boolean_constraint
 
     def compute_constraint(self, times, observer, targets):

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -22,7 +22,7 @@ import numpy as np
 # Package
 from .moon import moon_illumination
 from .utils import time_grid_from_range
-from .target import FixedTarget, get_icrs_skycoord
+from .target import FixedTarget, get_skycoord
 
 __all__ = ["AltitudeConstraint", "AirmassConstraint", "AtNightConstraint",
            "is_observable", "is_always_observable", "time_grid_from_range",
@@ -718,7 +718,7 @@ class MoonSeparationConstraint(Constraint):
             dists = u.Quantity([coord.distance for coord in moon_coords])
             moon = SkyCoord(AltAz(azs, alts, dists, obstime=obstime, location=observer.location))
 
-        targets = get_icrs_skycoord(targets)
+        targets = get_skycoord(targets)
 
         # has to be this way around, so the target coords are transformed to an
         # Earth-centred frame before calculating angular separation.

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -448,7 +448,7 @@ class AltitudeConstraint(Constraint):
             return max_best_rescale(alt, self.min, self.max)
 
 
-class AirmassConstraint(AltitudeConstraint):
+class AirmassConstraint(Constraint):
     """
     Constrain the airmass of a target.
 

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -357,13 +357,13 @@ class AltitudeConstraint(Constraint):
 
     def __init__(self, min=None, max=None, boolean_constraint=True):
         if min is None:
-            self.min = -90*u.deg
+            self.min = self._recast_limits(-90*u.deg)
         else:
-            self.min = min
+            self.min = self._recast_limits(min)
         if max is None:
-            self.max = 90*u.deg
+            self.max = self._recast_limits(90*u.deg)
         else:
-            self.max = max
+            self.max = self._recast_limits(max)
 
         self.boolean_constraint = boolean_constraint
 

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -756,8 +756,8 @@ class MoonIlluminationConstraint(Constraint):
             `~astropy.coordinates.solar_system_ephemeris` (which is
             set to 'builtin' by default).
         """
-        self.min = min if min is not None else 0.0
-        self.max = max if max is not None else 1.0
+        self.min = min if min is not None else -0.5
+        self.max = max if max is not None else 1.5
         self.ephemeris = ephemeris
 
     @classmethod
@@ -822,7 +822,7 @@ class MoonIlluminationConstraint(Constraint):
         cached_moon = _get_moon_data(times, observer)
         moon_alt = cached_moon['altaz'].alt
         moon_down_mask = moon_alt < 0
-        moon_up_mask = moon_alt >= 0
+        moon_up_mask = ~moon_down_mask
 
         illumination = cached_moon['illum']
 
@@ -831,11 +831,11 @@ class MoonIlluminationConstraint(Constraint):
         limits are (ntargets, 1). These will broadcast to make
         an (ntargets, ntimes) array
         """
-        if self.min is None and self.max is not None:
+        if self.min < 0 and self.max < 1.5:
             mask = (self.max >= illumination) | moon_down_mask
-        elif self.max is None and self.min is not None:
+        elif self.max > 1.0 and self.min > -0.5:
             mask = (self.min <= illumination) & moon_up_mask
-        elif self.min is not None and self.max is not None:
+        elif self.min > -0.5 and self.max < 1.5:
             mask = ((self.min <= illumination) &
                     (illumination <= self.max)) & moon_up_mask
         else:

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -328,10 +328,12 @@ class Constraint(object):
     def vectorize(self, constraint_list):
         """
         Given a list of constraints, return a vector constraint of this type.
+
         Parameters
         ----------
         constraint_list : list
             A list of `~astroplan.Constraint` objects.
+
         Returns
         -------
         constraint : `~astroplan.Constraint`

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -253,6 +253,9 @@ class Constraint(object):
         recast_limit : `~numpy.ndarray`
             The limit recast to the correct shape
         """
+        # do nothing if limit is None
+        if limit is None:
+            return None
         # change lists of Quantities to a non-scalar Quantity
         if isinstance(limit, list) and isinstance(limit[0], u.Quantity):
             limit = u.Quantity(limit)
@@ -267,6 +270,9 @@ class Constraint(object):
         (1,N) shape of the limits. This routine checks that, and raises a ValueError
         if not true.
         """
+        # do nothing if limit is None
+        if limit is None:
+            return
         # get shapes, or () if no shape attribute (i.e scalar)
         limit_shape = getattr(limit, 'shape', ())
         value_shape = getattr(values, 'shape', ())

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -543,7 +543,8 @@ class MoonSeparationConstraint(Constraint):
     def compute_constraint(self, times, observer, targets):
         moon = get_moon(times, observer.location, observer.pressure)
         targets = get_icrs_skycoord(targets)
-        moon_separation = moon.separation(targets[:, np.newaxis])
+        # has to be this way around
+        moon_separation = targets[:, np.newaxis].separation(moon)
         # check broadcastability
         self._check_limit_shape(moon_separation, self.min)
         self._check_limit_shape(moon_separation, self.max)

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -357,13 +357,13 @@ class AltitudeConstraint(Constraint):
 
     def __init__(self, min=None, max=None, boolean_constraint=True):
         if min is None:
-            self.min = self._recast_limits(-90*u.deg)
+            self.min = -90*u.deg
         else:
-            self.min = self._recast_limits(min)
+            self.min = min
         if max is None:
-            self.max = self._recast_limits(90*u.deg)
+            self.max = 90*u.deg
         else:
-            self.max = self._recast_limits(max)
+            self.max = max
 
         self.boolean_constraint = boolean_constraint
 
@@ -414,8 +414,8 @@ class AirmassConstraint(AltitudeConstraint):
     max = limit('max')
 
     def __init__(self, max=None, min=1, boolean_constraint=True):
-        self.min = self._recast_limits(min)
-        self.max = self._recast_limits(max)
+        self.min = min
+        self.max = max
         self.boolean_constraint = boolean_constraint
 
     def compute_constraint(self, times, observer, targets):
@@ -468,7 +468,7 @@ class AtNightConstraint(Constraint):
             Sun is below the horizon and the corrections for atmospheric
             refraction return nonsense values.
         """
-        self.max_solar_altitude = self._recast_limits(max_solar_altitude)
+        self.max_solar_altitude = max_solar_altitude
         self.force_pressure_zero = force_pressure_zero
 
     @classmethod
@@ -549,8 +549,8 @@ class SunSeparationConstraint(Constraint):
             Minimum acceptable separation between Sun and target (inclusive).
             `None` indicates no limit.
         """
-        self.min = self._recast_limits(min)
-        self.max = self._recast_limits(max)
+        self.min = min
+        self.max = max
 
     def compute_constraint(self, times, observer, targets):
         sunaltaz = observer.altaz(times, get_sun(times), grid=False)

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -187,6 +187,12 @@ def limit(storage_name):
     ...     def compute_constraint(self, times, observer, targets):
     ...             return np.atleast_2d(True)
     ...
+    ...     @classmethod
+    ...     def vectorize(cls, constraint_list):
+    ...         min_vals = _get_limit_values(constraint_list, 'min')
+    ...         max_vals = _get_limit_values(constraint_list, 'max')
+    ...         return cls(min_vals, max_vals)
+    ...
     >>>
     >>> cons = MyConstraint(max=2)
     >>> cons.max

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -880,7 +880,7 @@ class TimeConstraint(Constraint):
             valid_input = False
             try:
                 valid_input = all(isinstance(item, Time) for item in self.max)
-                self.max = Time(self.min)  # change lists of Times to a non-scalar Time
+                self.max = Time(self.max)  # change lists of Times to a non-scalar Time
             except:
                 valid_input = isinstance(self.max, Time)
             if not valid_input:

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -165,7 +165,6 @@ def _get_meridian_transit_times(times, observer, targets):
 
     return observer._meridian_transit_cache[aakey]
 
-
 @abstractmethod
 class Constraint(object):
     """
@@ -613,10 +612,7 @@ class MoonIlluminationConstraint(Constraint):
             raise ValueError("No max and/or min specified in "
                              "MoonSeparationConstraint.")
 
-        if targets is not None:
-            mask = np.tile(mask, len(targets))
-            mask = mask.reshape(len(targets), len(times))
-        return np.atleast_2d(mask)
+        return mask
 
 
 class LocalTimeConstraint(Constraint):

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -800,23 +800,21 @@ class TimeConstraint(Constraint):
 
         if self.min is not None:
             valid_input = False
-            if isinstance(self.min, Time):
-                valid_input = True
-            if isinstance(self.min, list):
+            try:
                 valid_input = all(isinstance(item, Time) for item in self.min)
-                if valid_input:
-                    self.min = Time(self.min)  # change lists of Times to a non-scalar Time
+                self.min = Time(self.min)  # change lists of Times to a non-scalar Time
+            except:
+                valid_input = isinstance(self.min, Time)
             if not valid_input:
                 raise TypeError("Time limits must be specified as astropy.time.Time objects.")
 
-        if self.min is not None:
+        if self.max is not None:
             valid_input = False
-            if isinstance(self.max, Time):
-                valid_input = True
-            if isinstance(self.max, list):
+            try:
                 valid_input = all(isinstance(item, Time) for item in self.max)
-                if valid_input:
-                    self.max = Time(self.max)  # change lists of Times to a non-scalar Time
+                self.max = Time(self.min)  # change lists of Times to a non-scalar Time
+            except:
+                valid_input = isinstance(self.max, Time)
             if not valid_input:
                 raise TypeError("Time limits must be specified as astropy.time.Time objects.")
 

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -7,11 +7,7 @@ from abc import ABCMeta
 
 # Third-party
 import astropy.units as u
-<<<<<<< HEAD
 from astropy.coordinates import SkyCoord, ICRS, UnitSphericalRepresentation
-=======
-from astropy.coordinates import SkyCoord, ICRS
->>>>>>> used get_skycoord defined in PR215
 
 __all__ = ["Target", "FixedTarget", "NonFixedTarget"]
 

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -186,7 +186,6 @@ class NonFixedTarget(Target):
     Placeholder for future function.
     """
 
-
 def get_skycoord(targets):
     """
     Return an `~astropy.coordinates.SkyCoord` object.
@@ -201,6 +200,7 @@ def get_skycoord(targets):
     -----------
     targets : list, `~astropy.coordinates.SkyCoord`, `Fixedtarget`
         either a single target or a list of targets
+
     Returns
     --------
     coord : `~astropy.coordinates.SkyCoord`

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -260,4 +260,3 @@ def get_skycoord(targets):
         """
         distances = [distance if distance != 1 else 100*u.kpc for distance in distances]
         return SkyCoord(longitudes, latitudes, distances, frame=frame)
-

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -7,7 +7,11 @@ from abc import ABCMeta
 
 # Third-party
 import astropy.units as u
+<<<<<<< HEAD
 from astropy.coordinates import SkyCoord, ICRS, UnitSphericalRepresentation
+=======
+from astropy.coordinates import SkyCoord, ICRS
+>>>>>>> used get_skycoord defined in PR215
 
 __all__ = ["Target", "FixedTarget", "NonFixedTarget"]
 
@@ -201,7 +205,6 @@ def get_skycoord(targets):
     -----------
     targets : list, `~astropy.coordinates.SkyCoord`, `Fixedtarget`
         either a single target or a list of targets
-
     Returns
     --------
     coord : `~astropy.coordinates.SkyCoord`

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -186,6 +186,7 @@ class NonFixedTarget(Target):
     Placeholder for future function.
     """
 
+
 def get_skycoord(targets):
     """
     Return an `~astropy.coordinates.SkyCoord` object.

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -260,3 +260,4 @@ def get_skycoord(targets):
         """
         distances = [distance if distance != 1 else 100*u.kpc for distance in distances]
         return SkyCoord(longitudes, latitudes, distances, frame=frame)
+

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -296,6 +296,14 @@ def test_docs_example():
             self.min = min
             self.max = max
 
+        @classmethod
+        def vectorize(cls, constraint_list):
+            # this function should take a list of constraints
+            # and return a vectorized version of this constraint
+            min_vals = _get_limit_vals(constraint_list, 'min')
+            max_vals = _get_limit_vals(constraint_list, 'max')
+            return cls(min_vals, max_vals)
+
         def compute_constraint(self, times, observer, targets):
 
             # Vega's coordinate must be non-scalar for the dimensions
@@ -324,9 +332,13 @@ def test_docs_example():
                 raise ValueError("No max and/or min specified in "
                                  "VegaSeparationConstraint.")
 
+
             # Return an array that is True where the target is observable and
             # False where it is not
-            return mask
+            # Must have shape (len(targets), len(times))
+
+            # currently mask has shape (len(targets), 1)
+            return np.tile(mask, len(times))
 
     constraints = [VegaSeparationConstraint(min=5*u.deg, max=30*u.deg)]
     observability = is_observable(constraints, subaru, targets,

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -402,3 +402,4 @@ def test_regression_shapes(constraint):
     assert constraint(lapalma, [targets[0]], times).shape == (1, 3)
     assert constraint(lapalma, [targets[0]], times[0]).shape == (1, 1)
     assert constraint(lapalma, targets, times[0]).shape == (2, 1)
+

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -396,12 +396,12 @@ def test_regression_shapes(constraint):
     times = Time(["2015-08-28 03:30", "2015-09-05 10:30", "2015-09-15 18:35"])
     targets = [FixedTarget(SkyCoord(350.7*u.deg, 18.4*u.deg)),
                FixedTarget(SkyCoord(260.7*u.deg, 22.4*u.deg))]
-    lapalma = Observer.at_site('lapalma')
+    keck = Observer.at_site('keck')
 
-    assert constraint(lapalma, targets, times).shape == (2, 3)
-    assert constraint(lapalma, [targets[0]], times).shape == (1, 3)
-    assert constraint(lapalma, [targets[0]], times[0]).shape == (1, 1)
-    assert constraint(lapalma, targets, times[0]).shape == (2, 1)
+    assert constraint(keck, targets, times).shape == (2, 3)
+    assert constraint(keck, [targets[0]], times).shape == (1, 3)
+    assert constraint(keck, [targets[0]], times[0]).shape == (1, 1)
+    assert constraint(keck, targets, times[0]).shape == (2, 1)
 
 
 vector_constraint_tests = [
@@ -421,8 +421,8 @@ def test_vector_constraints(constraint_idx):
     times = Time(["2015-08-28 03:30", "2015-09-05 10:30", "2015-09-15 18:35"])
     targets = [FixedTarget(SkyCoord(350.7*u.deg, 18.4*u.deg)),
                FixedTarget(SkyCoord(260.7*u.deg, 22.4*u.deg))]
-    lapalma = Observer.at_site('lapalma')
+    keck = Observer.at_site('keck')
     constraint = constraint_tests[constraint_idx]
     vconstraint = vector_constraint_tests[constraint_idx]
-    assert np.all(constraint(lapalma, targets, times) ==
-                  vconstraint(lapalma, targets, times))
+    assert np.all(constraint(keck, targets, times) ==
+                  vconstraint(keck, targets, times))

--- a/astroplan/tests/test_target.py
+++ b/astroplan/tests/test_target.py
@@ -59,12 +59,8 @@ def test_get_skycoord():
 
     coo = get_skycoord(m31)
     assert coo.is_equivalent_frame(ICRS())
-<<<<<<< HEAD
     with pytest.raises(TypeError) as exc_info:
         len(coo)
-=======
-    assert_raises(TypeError, len, coo)
->>>>>>> used get_skycoord defined in PR215
 
     coo = get_skycoord([m31])
     assert coo.is_equivalent_frame(ICRS())

--- a/astroplan/tests/test_target.py
+++ b/astroplan/tests/test_target.py
@@ -57,8 +57,12 @@ def test_get_skycoord():
 
     coo = get_skycoord(m31)
     assert coo.is_equivalent_frame(ICRS())
+<<<<<<< HEAD
     with pytest.raises(TypeError) as exc_info:
         len(coo)
+=======
+    assert_raises(TypeError, len, coo)
+>>>>>>> used get_skycoord defined in PR215
 
     coo = get_skycoord([m31])
     assert coo.is_equivalent_frame(ICRS())

--- a/astroplan/tests/test_target.py
+++ b/astroplan/tests/test_target.py
@@ -2,6 +2,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+from numpy.testing import assert_raises
+
 # Third-party
 import astropy.units as u
 from astropy.coordinates import SkyCoord, GCRS, ICRS

--- a/docs/tutorials/constraints.rst
+++ b/docs/tutorials/constraints.rst
@@ -274,8 +274,10 @@ Here's our ``VegaSeparationConstraint`` implementation::
 
         @classmethod
         def vectorize(cls, constraint_list):
-            # this function should take a list of constraints
-            # and return a vectorized version of this constraint
+            """
+            this function should take a list of constraints
+            and return a vectorized version of this constraint.
+            """
             min_vals = _get_limit_vals(constraint_list, 'min')
             max_vals = _get_limit_vals(constraint_list, 'max')
             return cls(min_vals, max_vals)

--- a/docs/tutorials/constraints.rst
+++ b/docs/tutorials/constraints.rst
@@ -253,6 +253,7 @@ Here's our ``VegaSeparationConstraint`` implementation::
     from astroplan import Constraint, is_observable, min_best_rescale
     from astropy.coordinates import Angle
     import astropy.units as u
+    from astroplan.constraints import _get_limit_vals
 
     class VegaSeparationConstraint(Constraint):
         """
@@ -270,6 +271,14 @@ Here's our ``VegaSeparationConstraint`` implementation::
             self.min = min
             self.max = max
             self.boolean_constraint = boolean_constraint
+
+        @classmethod
+        def vectorize(cls, constraint_list):
+            # this function should take a list of constraints
+            # and return a vectorized version of this constraint
+            min_vals = _get_limit_vals(constraint_list, 'min')
+            max_vals = _get_limit_vals(constraint_list, 'max')
+            return cls(min_vals, max_vals)
 
         def compute_constraint(self, times, observer, targets):
 


### PR DESCRIPTION
As outlined in #189, there is a case to be made that `Constraints` should be able to accept arrays for their minimum and maximum limits, where the length of those arrays is equal to the list of targets. This means a user with 100 targets each with slightly different `AltitudeConstraints` need not compute 100 `Constraints` with one target each, but a single `Constraint` with 100 targets. 

Since this would be so useful for my own use of `astroplan`, I went ahead and implemented the proposal in #189 to see if it made a big difference. In my tests, for this use case, allowing vectorised constraints leads to a factor 15 speedup for 100 targets. Also, the run time is almost independent of the number of targets, whilst the original code scales with the target number.

This PR builds on, and includes the changes made in, #165. Either that PR is considered redundant, or should be merged before this one.
