### PR TITLE
Faster alt/az calculations

### DIFF
--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -406,7 +406,9 @@ class Observer(object):
             coordinate = get_skycoord(target)
             if coordinate.isscalar:
                 return coordinate.transform_to(altaz_frame)
-            return coordinate[:, np.newaxis].transform_to(altaz_frame)
+            # TODO: remove ICRS conversion which is to avoid bug in GCRS-CIRS conversion
+            # (should be fixed by astropy/astropy#5104)
+            return coordinate.icrs[:, np.newaxis].transform_to(altaz_frame)
 
     def parallactic_angle(self, time, target):
         '''

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -437,7 +437,7 @@ class Observer(object):
         if not isinstance(time, Time):
             time = Time(time)
 
-        coordinate = get_skycoord(target)
+        coordinate = get_skycoord(target).icrs
 
         # Eqn (14.1) of Meeus' Astronomical Algorithms
         LST = time.sidereal_time('mean', longitude=self.location.longitude)

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -19,7 +19,7 @@ import pytz
 # Package
 from .exceptions import TargetNeverUpWarning, TargetAlwaysUpWarning
 from .moon import moon_illumination, moon_phase_angle
-from .target import get_icrs_skycoord
+from .target import get_skycoord
 
 __all__ = ["Observer", "MAGIC_TIME"]
 
@@ -403,7 +403,7 @@ class Observer(object):
             # Return just the frame
             return altaz_frame
         else:
-            coordinate = get_icrs_skycoord(target)
+            coordinate = get_skycoord(target)
             if coordinate.isscalar:
                 return coordinate.transform_to(altaz_frame)
             return coordinate[:, np.newaxis].transform_to(altaz_frame)
@@ -437,7 +437,7 @@ class Observer(object):
         if not isinstance(time, Time):
             time = Time(time)
 
-        coordinate = get_icrs_skycoord(target)
+        coordinate = get_skycoord(target)
 
         # Eqn (14.1) of Meeus' Astronomical Algorithms
         LST = time.sidereal_time('mean', longitude=self.location.longitude)

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -19,6 +19,7 @@ import pytz
 # Package
 from .exceptions import TargetNeverUpWarning, TargetAlwaysUpWarning
 from .moon import moon_illumination, moon_phase_angle
+from .target import get_icrs_skycoord
 
 __all__ = ["Observer", "MAGIC_TIME"]
 
@@ -339,58 +340,6 @@ class Observer(object):
 
         return Time(date_time, location=self.location)
 
-    def _transform_target_list_to_altaz(self, times, targets):
-        """
-        Workaround for transforming a list of coordinates ``targets`` to
-        altitudes and azimuths.
-
-        Parameters
-        ----------
-        times : `~astropy.time.Time` or list of `~astropy.time.Time` objects
-            Time of observation
-
-        targets : `~astropy.coordinates.SkyCoord` or list of `~astropy.coordinates.SkyCoord` objects
-            List of target coordinates
-
-        location : `~astropy.coordinates.EarthLocation`
-            Location of observer
-
-        Returns
-        -------
-        altitudes : list
-            List of altitudes for each target, at each time
-        """
-        if times.isscalar:
-            times = Time([times])
-
-        if not isinstance(targets, list) and targets.isscalar:
-            targets = [targets]
-
-        targets_is_unitsphericalrep = [x.data.__class__ is
-                                       UnitSphericalRepresentation for x in targets]
-        if all(targets_is_unitsphericalrep) or not any(targets_is_unitsphericalrep):
-            repeated_times = np.tile(times, len(targets))
-            ra_list = Longitude([x.icrs.ra for x in targets])
-            dec_list = Latitude([x.icrs.dec for x in targets])
-            repeated_ra = np.repeat(ra_list, len(times))
-            repeated_dec = np.repeat(dec_list, len(times))
-            inner_sc = SkyCoord(ra=repeated_ra, dec=repeated_dec)
-            target_SkyCoord = SkyCoord(inner_sc.data.represent_as(UnitSphericalRepresentation),
-                                       representation=UnitSphericalRepresentation)
-            transformed_coord = target_SkyCoord.transform_to(AltAz(location=self.location,
-                                                                   obstime=repeated_times))
-        else:
-            # TODO: This is super slow.
-            repeated_times = np.tile(times, len(targets))
-            repeated_targets = np.repeat(targets, len(times))
-            target_SkyCoord = SkyCoord(SkyCoord(repeated_targets).data.represent_as(
-                                       UnitSphericalRepresentation),
-                                       representation=UnitSphericalRepresentation)
-
-            transformed_coord = target_SkyCoord.transform_to(AltAz(location=self.location,
-                                                                   obstime=repeated_times))
-        return transformed_coord
-
     def altaz(self, time, target=None, obswl=None):
         """
         Get an `~astropy.coordinates.AltAz` frame or coordinate.
@@ -454,24 +403,10 @@ class Observer(object):
             # Return just the frame
             return altaz_frame
         else:
-            # If target is a list of targets:
-            if _target_is_vector(target):
-                get_coord = lambda x: x.coord if hasattr(x, 'coord') else x
-                transformed_coords = self._transform_target_list_to_altaz(time,
-                                          list(map(get_coord, target)))
-                n_targets = len(target)
-                new_shape = (n_targets, int(len(transformed_coords)/n_targets))
-
-                for comp in transformed_coords.data.components:
-                    getattr(transformed_coords.data, comp).resize(new_shape)
-                return transformed_coords
-
-            # If single target is a FixedTarget or a SkyCoord:
-            if hasattr(target, 'coord'):
-                coordinate = target.coord
-            else:
-                coordinate = target
-            return coordinate.transform_to(altaz_frame)
+            coordinate = get_icrs_skycoord(target)
+            if coordinate.isscalar:
+                return coordinate.transform_to(altaz_frame)
+            return coordinate[:, np.newaxis].transform_to(altaz_frame)
 
     def parallactic_angle(self, time, target):
         '''
@@ -502,14 +437,7 @@ class Observer(object):
         if not isinstance(time, Time):
             time = Time(time)
 
-        if _target_is_vector(target):
-            get_coord = lambda x: x.coord if hasattr(x, 'coord') else x
-            coordinate = SkyCoord(list(map(get_coord, target)))
-        else:
-            if hasattr(target, 'coord'):
-                coordinate = target.coord
-            else:
-                coordinate = target
+        coordinate = get_icrs_skycoord(target)
 
         # Eqn (14.1) of Meeus' Astronomical Algorithms
         LST = time.sidereal_time('mean', longitude=self.location.longitude)

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -172,3 +172,35 @@ class NonFixedTarget(Target):
     """
     Placeholder for future function.
     """
+
+
+def get_icrs_skycoord(targets):
+    """
+    Return an `~astropy.coordinates.SkyCoord` object, in the ICRS frame.
+
+    When performing calculations it is usually most efficient to have
+    a single `~astropy.coordinates.SkyCoord` object, rather than a
+    list of `FixedTarget` or `~astropy.coordinates.SkyCoord` objects.
+
+    Parameters
+    -----------
+    targets : list, `~astropy.coordinates.SkyCoord`, `Fixedtarget`
+        either a single target or a list of targets
+
+    Returns
+    --------
+    coord : `~astropy.coordinates.SkyCoord`
+        a single SkyCoord object, which may be non-scalar
+    """
+    if not isinstance(targets, list):
+        return getattr(targets, 'coord', targets)
+    coos = [getattr(target, 'coord', target) for target in targets]
+    # it is roughly 20 times faster to get ICRS RAs and DECs first,
+    # rather than initialise directly from list of SkyCoords
+    # (provided target list is all in ICRS frame)
+    ras = []
+    decs = []
+    for coo in coos:
+        ras.append(coo.icrs.ra)
+        decs.append(coo.icrs.dec)
+    return SkyCoord(ras, decs)

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -214,8 +214,8 @@ def get_skycoord(targets):
         # mixture of frames
         for coordinate in coords:
             icrs_coordinate = coordinate.icrs
-            ras.append(icrs_coordinate.ra)
-            decs.append(icrs_coordinate.dec)
+            longitudes.append(icrs_coordinate.ra)
+            latitudes.append(icrs_coordinate.dec)
             distances.append(icrs_coordinate.distance)
     else:
         # all the same frame, get the longitude and latitude names

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -205,7 +205,7 @@ def get_skycoord(targets):
 
     # we also need to be careful about handling mixtures of UnitSphericalRepresentations and others
     targets_is_unitsphericalrep = [x.data.__class__ is
-                                   UnitSphericalRepresentation for x in targets]
+                                   UnitSphericalRepresentation for x in coords]
 
     longitudes = []
     latitudes = []

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -193,14 +193,17 @@ def get_icrs_skycoord(targets):
         a single SkyCoord object, which may be non-scalar
     """
     if not isinstance(targets, list):
-        return getattr(targets, 'coord', targets)
-    coos = [getattr(target, 'coord', target) for target in targets]
+        return getattr(targets, 'coord', targets).icrs
+    coords = [getattr(target, 'coord', target) for target in targets]
     # it is roughly 20 times faster to get ICRS RAs and DECs first,
     # rather than initialise directly from list of SkyCoords
     # (provided target list is all in ICRS frame)
     ras = []
     decs = []
-    for coo in coos:
-        ras.append(coo.icrs.ra)
-        decs.append(coo.icrs.dec)
-    return SkyCoord(ras, decs)
+    distances = []
+    for coordinate in coords:
+        icrs_coordinate = coordinate.icrs
+        ras.append(icrs_coordinate.ra)
+        decs.append(icrs_coordinate.dec)
+        distances.append(icrs_coordinate.distance)
+    return SkyCoord(ras, decs, distances)

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -7,7 +7,7 @@ from abc import ABCMeta
 
 # Third-party
 import astropy.units as u
-from astropy.coordinates import SkyCoord, UnitSphericalRepresentation
+from astropy.coordinates import SkyCoord, UnitSphericalRepresentation, ICRS
 
 __all__ = ["Target", "FixedTarget", "NonFixedTarget"]
 
@@ -217,10 +217,12 @@ def get_skycoord(targets):
             longitudes.append(icrs_coordinate.ra)
             latitudes.append(icrs_coordinate.dec)
             distances.append(icrs_coordinate.distance)
+            frame = ICRS()
     else:
         # all the same frame, get the longitude and latitude names
         lon_name, lat_name = [mapping.framename for mapping in
                               coords[0].frame_specific_representation_info['spherical']]
+        frame = coords[0].frame
         for coordinate in coords:
             longitudes.append(getattr(coordinate, lon_name))
             latitudes.append(getattr(coordinate, lat_name))
@@ -237,5 +239,7 @@ def get_skycoord(targets):
         Instead, let's assign large distances to those objects with none.
         """
         distances = [distance if distance != 1 else 100*u.kpc for distance in distances]
-
-    return SkyCoord(longitudes, latitudes, distances)
+    if all([distance == 1 for distance in distances]):
+        return SkyCoord(longitudes, latitudes, frame=frame)
+    else:
+        return SkyCoord(longitudes, latitudes, distances, frame=frame)


### PR DESCRIPTION
This code dramatically increases the speed of altaz calculations, mainly by ensuring that we start from a `SkyCoord` object, rather than a list of `FixedTarget` object.

For 100 targets and 100 times, the speedup is a factor of 10 if the `target` argument is a list of `FixedTarget`s and 35x if the `target` argument is a non-scalar `SkyCoord`.

As an added bonus, the behaviour of `Observer.altaz` is now consistent, regardless of the type of the `target` argument, which was not the case before.

As an aside, it may mean that arguments to `Constraints` can also be vector `SkyCoord` objects instead of a list of `FixedTargets`. This will lead to faster code, so maybe we should think about changing the examples?
