### PR TITLE
Changing pytest import to use astropy bundled

### DIFF
--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -1,13 +1,13 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import datetime as dt
-import pytest
 
 import numpy as np
 import astropy.units as u
 from astropy.time import Time
 from astropy.coordinates import SkyCoord, get_sun, get_moon
 from astropy.utils import minversion
+from astropy.tests.helper import pytest
 
 from ..observer import Observer
 from ..target import FixedTarget


### PR DESCRIPTION
To be more consistent, and hopefully to solve @wtgee's https://github.com/astropy/astropy/issues/5202 issue.