### PR TITLE
Require moon to be up when there is a minimum moon illumination 

### DIFF
--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -550,21 +550,24 @@ class MoonIlluminationConstraint(Constraint):
         # first is the moon up?
         cached_moon = _get_moon_data(times, observer)
         moon_alt = cached_moon['altaz'].alt
-        moon_alt_mask = moon_alt < 0
+        moon_down_mask = moon_alt < 0
+        moon_up_mask = moon_alt >=0
 
         illumination = cached_moon['illum']
         if self.min is None and self.max is not None:
             mask = self.max >= illumination
+            mask = np.logical_or(moon_down_mask, mask)
         elif self.max is None and self.min is not None:
             mask = self.min <= illumination
+            mask = np.logical_and(moon_up_mask, mask)
         elif self.min is not None and self.max is not None:
             mask = ((self.min <= illumination) &
                     (illumination <= self.max))
+            mask = np.logical_and(moon_up_mask, mask)
         else:
             raise ValueError("No max and/or min specified in "
                              "MoonSeparationConstraint.")
 
-        mask = np.logical_or(moon_alt_mask, mask)
         if targets is not None:
             mask = np.tile(mask, len(targets))
             mask = mask.reshape(len(targets), len(times))

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -555,15 +555,12 @@ class MoonIlluminationConstraint(Constraint):
 
         illumination = cached_moon['illum']
         if self.min is None and self.max is not None:
-            mask = self.max >= illumination
-            mask = np.logical_or(moon_down_mask, mask)
+            mask = (self.max >= illumination) | moon_down_mask
         elif self.max is None and self.min is not None:
-            mask = self.min <= illumination
-            mask = np.logical_and(moon_up_mask, mask)
+            mask = (self.min <= illumination) & moon_up_mask
         elif self.min is not None and self.max is not None:
             mask = ((self.min <= illumination) &
-                    (illumination <= self.max))
-            mask = np.logical_and(moon_up_mask, mask)
+                    (illumination <= self.max)) & moon_up_mask
         else:
             raise ValueError("No max and/or min specified in "
                              "MoonSeparationConstraint.")

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -181,24 +181,29 @@ def test_moon_separation():
 
 
 def test_moon_illumination():
-    times = Time(["2015-08-28 03:30", "2015-09-05 10:30", "2015-09-15 18:35"])
+    times = Time(["2015-08-28 03:30", "2015-08-28 12:00",
+                  "2015-09-05 10:30", "2015-09-15 18:35"])
     lco = Observer.at_site("LCO")
     # At these times, moon illuminations are:
-    # [ 0.9600664 ,  0.49766145,  0.05427445]
+    # [ 0.9600664, 0.97507911, 0.49766145,  0.05427445]
     # and altitudes are:
-    # [ 73.53496408, 42.93207952, 66.46854598] deg
+    # [ 73.53496408, -24.55896688, 42.93207952, 66.46854598] deg
 
     constraint = MoonIlluminationConstraint(min=0.2, max=0.8)
     is_constraint_met = constraint(lco, None, times=times)
-    assert np.all(is_constraint_met == [False, True, False])
+    assert np.all(is_constraint_met == [False, False, True, False])
 
     constraint = MoonIlluminationConstraint(min=0.2)
     is_constraint_met = constraint(lco, None, times=times)
-    assert np.all(is_constraint_met == [True, True, False])
+    assert np.all(is_constraint_met == [True, False, True, False])
 
     constraint = MoonIlluminationConstraint(max=0.8)
     is_constraint_met = constraint(lco, None, times=times)
-    assert np.all(is_constraint_met == [False, True, True])
+    assert np.all(is_constraint_met == [False, True, True, True])
+
+    constraint = MoonIlluminationConstraint(max=0)
+    is_constraint_met = constraint(lco, None, times=times)
+    assert np.all(is_constraint_met == [False, True, False, False])
 
 
 def test_local_time_constraint_utc():


### PR DESCRIPTION
I made `MoonIlluminationConstraint` check whether the moon is up (`and`) when a minimum moon illumination is given, and when there is no minimum if the moon is not up (`or`). I also added a new time to the `test_moon_illumination_constraint` where the moon is below the horizon.