### PR TITLE
Removing location kwarg from moon illumination/phase computations

### DIFF
--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -83,10 +83,10 @@ def _get_altaz(times, observer, targets,
     return observer._altaz_cache[aakey]
 
 
-def _get_moon_data(times, observer,
-                   force_zero_pressure=False):
+def _get_moon_data(times, observer, force_zero_pressure=False):
     """
-    Calculate moon altitude az and illumination for an array of times for ``observer``.
+    Calculate moon altitude az and illumination for an array of times for
+    ``observer``.
 
     Cache the result on the ``observer`` object.
 
@@ -119,8 +119,7 @@ def _get_moon_data(times, observer,
                 observer.pressure = 0
 
             altaz = observer.moon_altaz(times)
-            illumination = np.array(moon_illumination(times,
-                                                      observer.location))
+            illumination = np.array(moon_illumination(times))
             observer._moon_cache[aakey] = dict(times=times,
                                                illum=illumination,
                                                altaz=altaz)
@@ -133,7 +132,8 @@ def _get_moon_data(times, observer,
 
 def _get_meridian_transit_times(times, observer, targets):
     """
-    Calculate next meridian transit for an array of times for ``targets`` and ``observer``.
+    Calculate next meridian transit for an array of times for ``targets`` and
+    ``observer``.
 
     Cache the result on the ``observer`` object.
 
@@ -162,7 +162,8 @@ def _get_meridian_transit_times(times, observer, targets):
 
     if aakey not in observer._meridian_transit_cache:
         meridian_transit_times = Time([observer.target_meridian_transit_time(
-                                       time, target, which='next') for target in targets
+                                       time, target, which='next')
+                                       for target in targets
                                        for time in times])
         observer._meridian_transit_cache[aakey] = dict(times=meridian_transit_times)
 
@@ -735,15 +736,18 @@ class TimeConstraint(Constraint):
         self.max = max
 
         if self.min is None and self.max is None:
-            raise ValueError("You must at least supply either a minimum or a maximum time.")
+            raise ValueError("You must at least supply either a minimum or a "
+                             "maximum time.")
 
         if self.min is not None:
             if not isinstance(self.min, Time):
-                raise TypeError("Time limits must be specified as astropy.time.Time objects.")
+                raise TypeError("Time limits must be specified as "
+                                "astropy.time.Time objects.")
 
         if self.max is not None:
             if not isinstance(self.max, Time):
-                raise TypeError("Time limits must be specified as astropy.time.Time objects.")
+                raise TypeError("Time limits must be specified as "
+                                "astropy.time.Time objects.")
 
     def compute_constraint(self, times, observer, targets):
         with warnings.catch_warnings():
@@ -979,7 +983,8 @@ def observability_table(constraints, observer, targets, times=None,
     always_obs = np.all(contraint_arr, axis=1)
     frac_obs = np.sum(contraint_arr, axis=1) / contraint_arr.shape[1]
 
-    tab = table.Table(names=colnames, data=[target_names, ever_obs, always_obs, frac_obs])
+    tab = table.Table(names=colnames, data=[target_names, ever_obs, always_obs,
+                                            frac_obs])
 
     if times is None and time_range is not None:
         times = time_grid_from_range(time_range,

--- a/astroplan/moon.py
+++ b/astroplan/moon.py
@@ -27,7 +27,7 @@ def moon_phase_angle(time, ephemeris=None):
 
     ephemeris : str, optional
         Ephemeris to use.  If not given, use the one set with
-        `~astropy.coordinates.solar_system_ephemeris.set` (which is
+        `~astropy.coordinates.solar_system_ephemeris` (which is
         set to 'builtin' by default).
 
     Returns
@@ -58,7 +58,7 @@ def moon_illumination(time, ephemeris=None):
 
     ephemeris : str, optional
         Ephemeris to use.  If not given, use the one set with
-        `~astropy.coordinates.solar_system_ephemeris.set` (which is
+        `~astropy.coordinates.solar_system_ephemeris` (which is
         set to 'builtin' by default).
 
     Returns

--- a/astroplan/moon.py
+++ b/astroplan/moon.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-This version of the `moon` module contains temporary solutions to calculating
-the position of the moon using astropy.coordinates.get_moon, awaiting solutions
-to the astropy issue [#5069](https://github.com/astropy/astropy/issues/5069).
+This version of the `moon` module calculates lunar phase angle for a geocentric
 """
 
 from __future__ import (absolute_import, division, print_function,
@@ -10,14 +8,14 @@ from __future__ import (absolute_import, division, print_function,
 
 # Third-party
 import numpy as np
-from astropy.coordinates import (get_moon, get_sun, AltAz, Angle)
+from astropy.coordinates import get_moon, get_sun
 
 __all__ = ["moon_phase_angle", "moon_illumination"]
 
 
-def moon_phase_angle(time, location, ephemeris=None):
+def moon_phase_angle(time, ephemeris=None):
     """
-    Calculate lunar orbital phase [radians].
+    Calculate lunar orbital phase in radians.
 
     Parameters
     ----------
@@ -29,7 +27,7 @@ def moon_phase_angle(time, location, ephemeris=None):
 
     ephemeris : str, optional
         Ephemeris to use.  If not given, use the one set with
-        ``astropy.coordinates.solar_system_ephemeris.set`` (which is
+        `~astropy.coordinates.solar_system_ephemeris.set` (which is
         set to 'builtin' by default).
 
     Returns
@@ -39,35 +37,16 @@ def moon_phase_angle(time, location, ephemeris=None):
     """
     # TODO: cache these sun/moon SkyCoord objects
 
-    # TODO: when astropy/astropy#5069 is resolved, replace this workaround which
-    # handles scalar and non-scalar time inputs differently
-
-    if time.isscalar:
-        altaz_frame = AltAz(location=location, obstime=time)
-        sun = get_sun(time).transform_to(altaz_frame)
-
-        moon = get_moon(time, location=location, ephemeris=ephemeris).transform_to(altaz_frame)
-        elongation = sun.separation(moon)
-        return np.arctan2(sun.distance*np.sin(elongation),
-                          moon.distance - sun.distance*np.cos(elongation))
-
-    else:
-        phase_angles = []
-        for t in time:
-            altaz_frame = AltAz(location=location, obstime=t)
-            moon_coord = get_moon(t, location=location, ephemeris=ephemeris).transform_to(altaz_frame)
-            sun_coord = get_sun(t).transform_to(altaz_frame)
-            elongation = sun_coord.separation(moon_coord)
-            phase_angle = np.arctan2(sun_coord.distance*np.sin(elongation),
-                                     moon_coord.distance -
-                                     sun_coord.distance*np.cos(elongation))
-            phase_angles.append(phase_angle)
-        return Angle(phase_angles)
+    sun = get_sun(time)
+    moon = get_moon(time, ephemeris=ephemeris)
+    elongation = sun.separation(moon)
+    return np.arctan2(sun.distance*np.sin(elongation),
+                      moon.distance - sun.distance*np.cos(elongation))
 
 
-def moon_illumination(time, location, ephemeris=None):
+def moon_illumination(time, ephemeris=None):
     """
-    Calculate fraction of the moon illuminated
+    Calculate fraction of the moon illuminated.
 
     Parameters
     ----------
@@ -79,7 +58,7 @@ def moon_illumination(time, location, ephemeris=None):
 
     ephemeris : str, optional
         Ephemeris to use.  If not given, use the one set with
-        ``astropy.coordinates.solar_system_ephemeris.set`` (which is
+        `~astropy.coordinates.solar_system_ephemeris.set` (which is
         set to 'builtin' by default).
 
     Returns
@@ -87,6 +66,6 @@ def moon_illumination(time, location, ephemeris=None):
     k : float
         Fraction of moon illuminated
     """
-    i = moon_phase_angle(time, location, ephemeris=ephemeris)
+    i = moon_phase_angle(time, ephemeris=ephemeris)
     k = (1 + np.cos(i))/2.0
     return k.value

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -1398,7 +1398,7 @@ class Observer(object):
         if not isinstance(time, Time):
             time = Time(time)
 
-        return moon_illumination(time, self.location)
+        return moon_illumination(time)
 
     def moon_phase(self, time=None):
         """
@@ -1435,7 +1435,7 @@ class Observer(object):
         if time is not None and not isinstance(time, Time):
             time = Time(time)
 
-        return moon_phase_angle(time, self.location)
+        return moon_phase_angle(time)
 
     def moon_altaz(self, time, ephemeris=None):
         """


### PR DESCRIPTION
This PR removes the location keyword argument from the `moon_illumination`, `moon_phase_angle` functions in the `moon` module. 

The motivation here is that astropy's `get_moon` does not yet support computations for multiple times at a non-geocentric observer, so we were calculating each moon position with a slow `for` loop (astropy/astropy#5216). While the location of the observer on the surface of the Earth matters a lot if you want precise moon positions on the celestial sphere, it doesn't affect the result much for computing moon phase/illumination compared to a geocentric observer. So we can get vast speed-ups if we just drop the location specification here, where it doesn't matter much.

I've simply removed the `location` keyword argument, which now computes all phases/illuminations from GCRS=(0, 0, 0). 

cc @StuartLittlefair @eteq @kvyh 