### PR TITLE
Added a utility function to get a non-scalar SkyCoord from a list of targets

### DIFF
--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -7,7 +7,7 @@ from abc import ABCMeta
 
 # Third-party
 import astropy.units as u
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import SkyCoord, ICRS, UnitSphericalRepresentation
 
 __all__ = ["Target", "FixedTarget", "NonFixedTarget"]
 

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -179,3 +179,77 @@ class NonFixedTarget(Target):
     """
     Placeholder for future function.
     """
+
+def get_skycoord(targets):
+    """
+    Return an `~astropy.coordinates.SkyCoord` object.
+
+    When performing calculations it is usually most efficient to have
+    a single `~astropy.coordinates.SkyCoord` object, rather than a
+    list of `FixedTarget` or `~astropy.coordinates.SkyCoord` objects.
+
+    This is a convenience routine to do that.
+
+    Parameters
+    -----------
+    targets : list, `~astropy.coordinates.SkyCoord`, `Fixedtarget`
+        either a single target or a list of targets
+
+    Returns
+    --------
+    coord : `~astropy.coordinates.SkyCoord`
+        a single SkyCoord object, which may be non-scalar
+    """
+    if not isinstance(targets, list):
+        return getattr(targets, 'coord', targets)
+
+    # get the SkyCoord object itself
+    coords = [getattr(target, 'coord', target) for target in targets]
+
+    # are all SkyCoordinate's in equivalent frames? If not, convert to ICRS
+    convert_to_icrs = not all([coord.frame.is_equivalent_frame(coords[0].frame) for coord in coords[1:]])
+
+    # we also need to be careful about handling mixtures of UnitSphericalRepresentations and others
+    targets_is_unitsphericalrep = [x.data.__class__ is
+                                   UnitSphericalRepresentation for x in coords]
+
+    longitudes = []
+    latitudes = []
+    distances = []
+    get_distances = not all(targets_is_unitsphericalrep)
+    if convert_to_icrs:
+        # mixture of frames
+        for coordinate in coords:
+            icrs_coordinate = coordinate.icrs
+            longitudes.append(icrs_coordinate.ra)
+            latitudes.append(icrs_coordinate.dec)
+            if get_distances:
+                distances.append(icrs_coordinate.distance)
+        frame = ICRS()
+    else:
+        # all the same frame, get the longitude and latitude names
+        lon_name, lat_name = [mapping.framename for mapping in
+                              coords[0].frame_specific_representation_info['spherical']]
+        frame = coords[0].frame
+        for coordinate in coords:
+            longitudes.append(getattr(coordinate, lon_name))
+            latitudes.append(getattr(coordinate, lat_name))
+            if get_distances:
+                distances.append(coordinate.distance)
+
+    # now let's deal with the fact that we may have a mixture of coords with distances and
+    # coords with UnitSphericalRepresentations
+    if all(targets_is_unitsphericalrep):
+        return SkyCoord(longitudes, latitudes, frame=frame)
+    elif not any(targets_is_unitsphericalrep):
+        return SkyCoord(longitudes, latitudes, distances, frame=frame)
+    else:
+        """
+        We have a mixture of coords with distances and without.
+        Since we don't know in advance the origin of the frame where further transformation
+        will take place, it's not safe to drop the distances from those coords with them set.
+
+        Instead, let's assign large distances to those objects with none.
+        """
+        distances = [distance if distance != 1 else 100*u.kpc for distance in distances]
+        return SkyCoord(longitudes, latitudes, distances, frame=frame)

--- a/astroplan/tests/test_target.py
+++ b/astroplan/tests/test_target.py
@@ -6,7 +6,8 @@ from numpy.testing import assert_raises
 
 # Third-party
 import astropy.units as u
-from astropy.coordinates import SkyCoord, GCRS
+from astropy.coordinates import SkyCoord, GCRS, ICRS
+from astropy.time import Time
 
 # Package
 from ..target import FixedTarget, get_skycoord


### PR DESCRIPTION
The rationale behind this PR is that it is often faster to make calculations with a non-scalar SkyCoord than with a list of `FixedTarget` objects or `SkyCoord` objects. However, making the conversion is non-trivial so a helper function is required.

The utility function described here will return a `SkyCoord` object when passed either:
- a single `FixedTarget` or `SkyCoord`
- a list of `FixedTarget`s or `SkyCoord`s.

In the latter case, the returned `SkyCoord` will be non-scalar.

In the case where all of the supplied target coordinates are in the same frame, no conversion will take place. If there is a mix of frames, all coordinates will be converted to `ICRS`.

One potentially controversial decision is what to do when there is a mix of coordinates with distances and those without. You cannot create a `SkyCoord` with a mix like this. It is, IMO, not right to discard the distances from targets that have them, since any transformation into a frame with a different origin will be incorrect. Instead, I assign an arbitrary, large, distance to those targets which lack it.
