### PR TITLE
Fix `tonight` method to incorporate horizon at initial time check

### DIFF
--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -1696,7 +1696,7 @@ class Observer(object):
             A tuple of times corresponding to the start and end of current night
         """
         current_time = Time.now() if time is None else time
-        if self.is_night(current_time):
+        if self.is_night(current_time, horizon=horizon):
             start_time = current_time
         else:
             start_time = self.sun_set_time(current_time, which='next', horizon=horizon)

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -1672,7 +1672,7 @@ class Observer(object):
         return hour_angle
 
     @u.quantity_input(horizon=u.degree)
-    def tonight(self, time=None, horizon=0 * u.degree):
+    def tonight(self, time=None, horizon=0 * u.degree, obswl=None):
         """
         Return a time range corresponding to the nearest night
 
@@ -1689,6 +1689,8 @@ class Observer(object):
         horizon : `~astropy.units.Quantity` (optional), default = zero degrees
             Degrees above/below actual horizon to use for calculating rise/set times
             (e.g., -6 deg horizon = civil twilight, etc.)
+        obswl : `~astropy.units.Quantity` (optional)
+            Wavelength of the observation used in the calculation
 
         Returns
         -------
@@ -1696,7 +1698,7 @@ class Observer(object):
             A tuple of times corresponding to the start and end of current night
         """
         current_time = Time.now() if time is None else time
-        if self.is_night(current_time, horizon=horizon):
+        if self.is_night(current_time, horizon=horizon, obswl=obswl):
             start_time = current_time
         else:
             start_time = self.sun_set_time(current_time, which='next', horizon=horizon)

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -1195,6 +1195,8 @@ def test_tonight():
     obs = Observer.at_site('subaru')
     obs.height = 0 * u.m
 
+    horizon = 0 * u.degree
+
     noon = Time('2016-02-03 22:00:00')
     midnight = Time('2016-02-04 10:00:00')
 
@@ -1203,8 +1205,8 @@ def test_tonight():
 
     threshold_minutes = 6
 
-    during_day = obs.tonight(time=noon)
-    during_night = obs.tonight(time=midnight)
+    during_day = obs.tonight(time=noon, horizon=horizon)
+    during_night = obs.tonight(time=midnight, horizon=horizon)
     
     assert (abs(sunset - during_day[0].datetime) < 
         datetime.timedelta(minutes=threshold_minutes))
@@ -1214,4 +1216,15 @@ def test_tonight():
     assert (abs(midnight.datetime - during_night[0].datetime) < 
         datetime.timedelta(minutes=threshold_minutes))
     assert (abs(sunrise - during_night[1].datetime) < 
+        datetime.timedelta(minutes=threshold_minutes))
+
+    astro_sunset = Time('2016-08-08 06:13:00')
+    horizon = -18 * u.degree
+
+    post_civil_sunset = Time('2016-08-08 05:00:00')
+    during_twilight = obs.tonight(time=post_civil_sunset, horizon=horizon)
+    during_twilight_wo_horizon = obs.tonight(time=post_civil_sunset)
+
+    # Get correct astro sunset if checking after civil sunset
+    assert (abs(astro_sunset.datetime - during_twilight[0].datetime) <
         datetime.timedelta(minutes=threshold_minutes))


### PR DESCRIPTION
Incorrect sunset times were being reported because of lack of `horizon` check on `is_night`. This happens if you check for `tonight` after `0 deg` but before passed `horizon`.

@bmorris3 I suppose wavelength should be included too?