### PR TITLE
Make the FixedTarget.from_name method easier to discover

### DIFF
--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -101,8 +101,11 @@ class FixedTarget(Target):
     @classmethod
     def from_name(cls, query_name, name=None, **kwargs):
         """
-        Initialize a `FixedTarget` by querying for a name, using the machinery
-        in `~astropy.coordinates.SkyCoord.from_name`.
+        Initialize a `FixedTarget` by querying for a name from the CDS name
+        resolver, using the machinery in
+        `~astropy.coordinates.SkyCoord.from_name`.
+
+        This
 
         Parameters
         ----------
@@ -158,7 +161,8 @@ class FixedTarget(Target):
             "sirius": {"ra": 101.28715533*u.deg, "dec": -16.71611586*u.deg},
             "vega": {"ra": 279.23473479*u.deg, "dec": 38.78368896*u.deg},
             "aldebaran": {"ra": 68.98016279*u.deg, "dec": 16.50930235*u.deg},
-            "polaris": {"ra": 37.95456067*u.deg, "dec": 89.26410897*u.deg}
+            "polaris": {"ra": 37.95456067*u.deg, "dec": 89.26410897*u.deg},
+            "altair": {"ra": 297.6958273*u.deg, "dec": 8.8683212*u.deg}
         }
 
         if query_name.lower() in stars:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -23,6 +23,11 @@ an `~astroplan.FixedTarget` object::
     coordinates = SkyCoord('19h50m47.6s', '+08d52m12.0s', frame='icrs')
     altair = FixedTarget(name='Altair', coord=coordinates)
 
+Alternatively, for objects known to the CDS name resolver, you can quickly
+retrieve their coordinates with `~astroplan.FixedTarget.from_name`::
+
+    altair = FixedTarget.from_name('Altair')
+
 Similarly, an `~astroplan.Observer` object contains information about the
 observatory, telescope or place where you are observing, such as longitude,
 latitude, elevation and other optional parameters.  You can initialize an

--- a/docs/tutorials/summer_triangle.rst
+++ b/docs/tutorials/summer_triangle.rst
@@ -48,20 +48,25 @@ First, we define our `~astroplan.Observer` object:
 
     >>> subaru = Observer.at_site('subaru')
 
-Then, we define our `~astroplan.Target` objects (`~astroplan.FixedTarget`'s
-in this case, since the Summer Triangle is fixed with respect to the
-celestial sphere if we ignore the relatively small proper motion):
+Then, we define our `~astroplan.FixedTarget`'s, since the Summer Triangle is
+fixed with respect to the celestial sphere (if we ignore the relatively small
+proper motion). We will use the `~astroplan.FixedTarget.from_name` class method,
+which queries the CDS name resolver for your target's coordinates (giving you
+the power of SIMBAD!):
 
 .. code-block:: python
 
     >>> from astropy.coordinates import SkyCoord
     >>> from astroplan import FixedTarget
 
-    >>> coordinates = SkyCoord('19h50m47.6s', '+08d52m12.0s', frame='icrs')
-    >>> altair = FixedTarget(name='Altair', coord=coordinates)
+    >>> altair = FixedTarget.from_name('Altair')
+    >>> vega = FixedTarget.from_name('Vega')
 
-    >>> coordinates = SkyCoord('18h36m56.5s', '+38d47m06.6s', frame='icrs')
-    >>> vega = FixedTarget(name='Vega', coord=coordinates)
+
+For objects that can't be resolved with `~astroplan.FixedTarget.from_name`, you
+can enter coordinates manually:
+
+.. code-block:: python
 
     >>> coordinates = SkyCoord('20h41m25.9s', '+45d16m49.3s', frame='icrs')
     >>> deneb = FixedTarget(name='Deneb', coord=coordinates)


### PR DESCRIPTION
Here I rearrange the docs to make it easier to discover the `FixedTarget.from_name` method.

This is partially in response to a [thread on astropy-dev](https://groups.google.com/d/msg/astropy-dev/akVp7vCwebg/lK6iVFw6CAAJ) where it seems some users aren't aware of the method, probably because the docs tutorials don't use `FixedTarget.from_name` much. 

Closes #226.

cc @bsipocz @cdeil 