### PR TITLE
Adding conda channels to CI files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
         - CONDA_DEPENDENCIES='pytz'
         - PIP_DEPENDENCIES=''
         - SETUP_CMD='test -V'
+        - CONDA_CHANNELS='astropy'
 
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ environment:
                         # to the matrix section.
       CONDA_DEPENDENCIES: "pytz matplotlib nose"
       PIP_DEPENDENCIES: "pyephem pytest-mpl"
+      CONDA_CHANNELS: "astropy"
 
   matrix:
 


### PR DESCRIPTION
Conda channels now need to be explicitly listed, ci-helpers won't add astropy and astropy-ci-extras by default in the future astropy/ci-helpers#128.