### PR TITLE
Added timezones to sites and made init of Observer easier

### DIFF
--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -30,7 +30,7 @@ def show_sites():
     Shows all available observing sites
     """
     for key, item in EarthLocation._get_site_registry()._loaded_jsondb.items():
-        print('%-15s: %s' % (key, item.get('name', "")))
+        print('{0:<15}: {1}'.format(key, item.get('name', "")))
 
 
 def _generate_24hr_grid(t0, start, end, N, for_deriv=False):
@@ -90,14 +90,14 @@ class Observer(object):
     Examples
     --------
     We can create an observer at Subaru Observatory in Hawaii three ways. First,
-    locations for some observatories are stored in astroplan, and these can be
+    locations for some observatories are stored in astropy, and these can be
     accessed by name, like so:
 
     >>> from astroplan import Observer
     >>> subaru = Observer("Subaru")
 
     To find out which observatories can be accessed by name, check out
-    `show_sites`.
+    `~astroplan.show_sites`.
 
     Next, you can initialize an observer by specifying the location with
     `~astropy.coordinates.EarthLocation`:

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -176,25 +176,24 @@ class Observer(object):
                                                         elevation)
         elif isinstance(location, EarthLocation):
             self.location = location
+        elif isinstance(location, string_types):
+            self.location = EarthLocation.of_site(location)
+            low_case_mapping = {}
+            full_raw_data = EarthLocation._get_site_registry()._loaded_jsondb
+            for key in full_raw_data:
+                low_case_mapping[key.lower()] = key
+            raw_site = full_raw_data[low_case_mapping[location.lower()]]
+            self.name = raw_site['name'] if (self.name is None) else self.name
+            timezone = raw_site.get('timezone', timezone)
         else:
-            try:
-                self.location = EarthLocation.of_site(location)
-                low_case_mapping = {}
-                full_raw_data = EarthLocation._get_site_registry()._loaded_jsondb
-                for key in full_raw_data:
-                    low_case_mapping[key.lower()] = key
-                raw_site = full_raw_data[low_case_mapping[location.lower()]]
-                self.name = raw_site['name'] if (self.name is None) else self.name
-                timezone = raw_site.get('timezone', timezone)
-            except:
-                raise TypeError('Observatory location must be specified with '
-                                'either (1) an instance of '
-                                'astropy.coordinates.EarthLocation or (2) '
-                                'latitude and longitude in degrees as '
-                                'accepted by astropy.coordinates.Latitude and '
-                                'astropy.coordinates.Latitude or (3) an '
-                                'observing site from the list '
-                                '`show_sites`.')
+            raise TypeError('Observatory location must be specified with '
+                            'either (1) an instance of '
+                            'astropy.coordinates.EarthLocation or (2) '
+                            'latitude and longitude in degrees as '
+                            'accepted by astropy.coordinates.Latitude and '
+                            'astropy.coordinates.Latitude or (3) an '
+                            'observing site from the list '
+                            '`show_sites`.')
 
         # Accept various timezone inputs, default to UTC if not known site
         if isinstance(timezone, datetime.tzinfo):

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -178,11 +178,9 @@ class Observer(object):
             self.location = location
         elif isinstance(location, string_types):
             self.location = EarthLocation.of_site(location)
-            low_case_mapping = {}
-            full_raw_data = EarthLocation._get_site_registry()._loaded_jsondb
-            for key in full_raw_data:
-                low_case_mapping[key.lower()] = key
-            raw_site = full_raw_data[low_case_mapping[location.lower()]]
+            for key, raw_site in EarthLocation._get_site_registry()._loaded_jsondb.items():
+                if key.lower() == location.lower():
+                    break
             self.name = raw_site['name'] if (self.name is None) else self.name
             timezone = raw_site.get('timezone', timezone)
         else:

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -89,12 +89,12 @@ class Observer(object):
 
     Examples
     --------
-    We can create an observer at Subaru Observatory in Hawaii two ways. First,
+    We can create an observer at Subaru Observatory in Hawaii three ways. First,
     locations for some observatories are stored in astroplan, and these can be
     accessed by name, like so:
 
     >>> from astroplan import Observer
-    >>> subaru = Observer.at_site("Subaru", timezone="US/Hawaii")
+    >>> subaru = Observer("Subaru")
 
     To find out which observatories can be accessed by name, check out
     `show_sites`.

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -129,7 +129,7 @@ class Observer(object):
 
         location : `~astropy.coordinates.EarthLocation`
             The location (latitude, longitude, elevation) of the observatory,
-            or, the observing site name, see `show_sites` (in this case, the
+            or, the observing site name, see `~astroplan.show_sites` (in this case, the
             fields timezone, name, latitude, longitude, elevation will be
             defaulted to the observatory values)
 
@@ -191,7 +191,7 @@ class Observer(object):
                             'accepted by astropy.coordinates.Latitude and '
                             'astropy.coordinates.Latitude or (3) an '
                             'observing site from the list '
-                            '`show_sites`.')
+                            '`~astroplan.show_sites`.')
 
         # Accept various timezone inputs, default to UTC if not known site
         if isinstance(timezone, datetime.tzinfo):

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -178,9 +178,12 @@ class Observer(object):
             self.location = location
         else:
             try:
-                location = str(location).lower()
                 self.location = EarthLocation.of_site(location)
-                raw_site = EarthLocation._get_site_registry()._loaded_jsondb[location]
+                low_case_mapping = {}
+                full_raw_data = EarthLocation._get_site_registry()._loaded_jsondb
+                for key in full_raw_data:
+                    low_case_mapping[key.lower()] = key
+                raw_site = full_raw_data[low_case_mapping[location.lower()]]
                 self.name = raw_site['name'] if (self.name is None) else self.name
                 timezone = raw_site.get('timezone', timezone)
             except:


### PR DESCRIPTION
This PR is related to this one https://github.com/astropy/astropy-data/pull/16 on astropy, that aims at incorporating the timezone information in the observation sites database.
With this PR, `Observer("subaru")` and `Observer.of_site("subaru")` are equivalent. There is no need to provide the timezone anymore when one uses a registered site.
There is an additional convenience function `show_sites` which prints all sites keys and sites full names.