### PR TITLE
Using a filled schedule as input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,11 +71,11 @@ matrix:
         # 2.7.
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='test --remote-data -V --coverage'
-               CONDA_DEPENDENCIES='pytz matplotlib nose qt=4'
+               CONDA_DEPENDENCIES='pytz matplotlib nose'
                PIP_DEPENDENCIES='pytest-mpl'
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='test --remote-data -V'
-               CONDA_DEPENDENCIES='pytz matplotlib nose qt=4'
+               CONDA_DEPENDENCIES='pytz matplotlib nose'
                PIP_DEPENDENCIES='pytest-mpl'
 
         # Try older numpy versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,11 @@ matrix:
         # plot_directive in sphinx needs them
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES='pytz matplotlib nose wcsaxes astroquery'
+               CONDA_DEPENDENCIES='pytz matplotlib nose wcsaxes astroquery qt=4'
                PIP_DEPENDENCIES='pytest-mpl'
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES='pytz matplotlib nose wcsaxes astroquery'
+               CONDA_DEPENDENCIES='pytz matplotlib nose wcsaxes astroquery qt=4'
                PIP_DEPENDENCIES='pytest-mpl'
 
         # Try all python versions with the latest numpy
@@ -71,11 +71,11 @@ matrix:
         # 2.7.
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='test --remote-data -V --coverage'
-               CONDA_DEPENDENCIES='pytz matplotlib nose'
+               CONDA_DEPENDENCIES='pytz matplotlib nose qt=4'
                PIP_DEPENDENCIES='pytest-mpl'
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='test --remote-data -V'
-               CONDA_DEPENDENCIES='pytz matplotlib nose'
+               CONDA_DEPENDENCIES='pytz matplotlib nose qt=4'
                PIP_DEPENDENCIES='pytest-mpl'
 
         # Try older numpy versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES='pytz qt=4'
+        - CONDA_DEPENDENCIES='pytz'
         - PIP_DEPENDENCIES=''
         - SETUP_CMD='test -V'
         - CONDA_CHANNELS='astropy'

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES='pytz'
+        - CONDA_DEPENDENCIES='pytz qt=4'
         - PIP_DEPENDENCIES=''
         - SETUP_CMD='test -V'
         - CONDA_CHANNELS='astropy'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-      CONDA_DEPENDENCIES: "pytz matplotlib nose"
+      CONDA_DEPENDENCIES: "pytz matplotlib nose qt=4"
       PIP_DEPENDENCIES: "pyephem pytest-mpl"
       CONDA_CHANNELS: "astropy"
 

--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -305,7 +305,6 @@ class Schedule(object):
                     and (slot.end > start_time + 1*u.second)):
                 slot_index = j
         if (block.duration - self.slots[slot_index].duration) > 1*u.second:
-            print(self.slots[slot_index].duration.to(u.second), block.duration)
             raise ValueError('longer block than slot')
         elif self.slots[slot_index].end - block.duration < start_time:
             start_time = self.slots[slot_index].end - block.duration
@@ -518,7 +517,6 @@ class SequentialScheduler(Scheduler):
         else:
             filled_times = Time(pre_filled.flatten())
             pre_filled = filled_times.reshape((len(filled_times)/2, 2))
-        print(pre_filled)
         for b in blocks:
             if b.constraints is None:
                 b._all_constraints = self.constraints

--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -552,11 +552,8 @@ class SequentialScheduler(Scheduler):
                 times = current_time + transition_time + b._duration_offsets
 
                 # make sure it isn't in a pre-filled slot
-                a = set(np.where(current_time < filled_times)[0])
-                c = set(np.where(filled_times < times[2])[0])
-                print(set.intersection(a, c))
-                if (set.intersection(a, c) or
-                        any(1*u.second > abs(pre_filled.T[0]-current_time))):
+                if (any((current_time < filled_times) & (filled_times < times[2])) or
+                        any(abs(pre_filled.T[0]-current_time) < 1*u.second)):
                     block_constraint_results.append(0)
 
                 else:

--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -633,7 +633,13 @@ class PriorityScheduler(Scheduler):
         times = time_grid_from_range([self.schedule.start_time, self.schedule.end_time],
                                      time_resolution=time_resolution)
         is_open_time = np.ones(len(times), bool)
-
+        # close times that are already filled
+        pre_filled = np.array([[block.start_time, block.end_time] for
+                               block in self.schedule.scheduled_blocks])
+        for start_end in pre_filled:
+            filled = np.where((start_end[0] < times) & (times < start_end[1]))
+            is_open_time[filled[0]] = False
+            is_open_time[min(filled[0]) - 1] = False
         # generate the score arrays for all of the blocks
         scorer = Scorer(blocks, self.observer, self.schedule, global_constraints=self.constraints)
         score_array = scorer.create_score_array(time_resolution)

--- a/astroplan/tests/test_scheduling.py
+++ b/astroplan/tests/test_scheduling.py
@@ -151,6 +151,10 @@ def test_priority_scheduler():
     # polaris and rigel both peak just before the start time
     assert schedule.slots[0].block.target == polaris
     assert schedule.slots[2].block.target == rigel
+    # test that the scheduler does not error when called with a partially
+    # filled schedule
+    scheduler(blocks, schedule)
+    scheduler(blocks, schedule)
 
 
 def test_sequential_scheduler():

--- a/astroplan/tests/test_scheduling.py
+++ b/astroplan/tests/test_scheduling.py
@@ -159,7 +159,8 @@ def test_sequential_scheduler():
     start_time = Time('2016-02-06 03:00:00')
     end_time = start_time + 18 * u.hour
     scheduler = SequentialScheduler(constraints=constraints, observer=apo,
-                                    transitioner=default_transitioner)
+                                    transitioner=default_transitioner,
+                                    gap_time=15*u.minute)
     schedule = Schedule(start_time, end_time)
     scheduler(blocks, schedule)
     assert len(schedule.observing_blocks) > 0
@@ -170,6 +171,10 @@ def test_sequential_scheduler():
                 schedule.observing_blocks[2].target == vega])
     # vega rises late, so its start should be later
     assert schedule.observing_blocks[2].start_time > start_time + 8*u.hour
+    # test that the scheduler does not error when called with a partially
+    # filled schedule
+    scheduler(blocks, schedule)
+    scheduler(blocks, schedule)
 
 
 def test_scheduling_target_down():


### PR DESCRIPTION
With this, both `Schedulers` can handle a previously filled schedule as their input. I will be adding another commit soon that includes this functionality in the Tutorial. This adds the desired functionality of #217 and  #209.