### PR TITLE
Removing workaround of qt version pinning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,11 @@ matrix:
         # plot_directive in sphinx needs them
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES='pytz matplotlib nose wcsaxes astroquery qt=4'
+               CONDA_DEPENDENCIES='pytz matplotlib nose wcsaxes astroquery'
                PIP_DEPENDENCIES='pytest-mpl'
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES='pytz matplotlib nose wcsaxes astroquery qt=4'
+               CONDA_DEPENDENCIES='pytz matplotlib nose wcsaxes astroquery'
                PIP_DEPENDENCIES='pytest-mpl'
 
         # Try all python versions with the latest numpy

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-      CONDA_DEPENDENCIES: "pytz matplotlib nose qt=4"
+      CONDA_DEPENDENCIES: "pytz matplotlib nose"
       PIP_DEPENDENCIES: "pyephem pytest-mpl"
       CONDA_CHANNELS: "astropy"
 


### PR DESCRIPTION
This should pass now and fix #248.