### PR TITLE
Adding AzimuthConstraint

### DIFF
--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -437,7 +437,7 @@ class AzimuthConstraint(Constraint):
         This may misbehave if you try to constrain negative azimuth, as
         the `~astropy.coordinates.AltAz` frame tends to mishandle negative.
         This could occur when you are wanting targets towards the north with
-        a minimum azimuth towards the northwest, e.g, azimuth 3 15 (== -45), and a
+        a minimum azimuth towards the northwest, e.g, azimuth 315 (== -45), and a
         maximum azimuth toward the northeast, e.g., azimuth 45.
 
 
@@ -472,7 +472,7 @@ class AzimuthConstraint(Constraint):
             uppermask = az <= self.max
             return lowermask & uppermask
         else:
-            return max_best_rescale(alt, self.min, self.max)
+            return max_best_rescale(az, self.min, self.max)
 
 
 class SunSeparationConstraint(Constraint):

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -434,11 +434,12 @@ class AzimuthConstraint(Constraint):
     Constrain the azimuth of the target.
 
     .. note::
-        This may misbehave if you try to constrain negative azimuth, as
-        the `~astropy.coordinates.AltAz` frame tends to mishandle negative.
-        This could occur when you are wanting targets towards the north with
+        This will misbehave if you try to constrain negative azimuths.
+        An example could be attempting to schedule targets towards the north with
         a minimum azimuth towards the northwest, e.g, azimuth 315 (== -45), and a
-        maximum azimuth toward the northeast, e.g., azimuth 45.
+        maximum azimuth toward the northeast, e.g., azimuth 45.  Use positive 
+        azimuths for the minimum and maximum with a larger value for the 
+        maximum than for the minimum.
 
 
     Parameters


### PR DESCRIPTION
Adding a proposed azimuth constraint.  The constraint is very similar to the existing AltitudeConstraint, but constraints azimuth instead of altitude.  This constraint can be used to limit targets based upon their azimuth, such as in the downwind direction to reduce wind buffeting.   This helps in scheduling during marginal observing conditions that result from high winds.
