### PR TITLE
Checking that not all points are masked before formatting time axis

### DIFF
--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -167,9 +167,10 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
         ax.plot_date(time.plot_date, masked_airmass, label=target_name, **style_kwargs)
 
     # Format the time axis
-    date_formatter = dates.DateFormatter('%H:%M')
-    ax.xaxis.set_major_formatter(date_formatter)
-    plt.setp(ax.get_xticklabels(), rotation=30, ha='right')
+    if not np.all(masked_airmass.mask):
+        date_formatter = dates.DateFormatter('%H:%M')
+        ax.xaxis.set_major_formatter(date_formatter)
+        plt.setp(ax.get_xticklabels(), rotation=30, ha='right')
 
     # Shade background during night time
     if brightness_shading:


### PR DESCRIPTION
This closes #259.

When `plot_airmass` is called on a target that is never above the horizon, the altitude array that gets passed to the plotting function is completely masked, and therefore a call to `ax.get_xticklabels()` throws an error. This fix checks that not all airmasses are masked before reformatting the axis.