### PR TITLE
Input checking for ``time_range`` parameters

### DIFF
--- a/astroplan/tests/test_utils.py
+++ b/astroplan/tests/test_utils.py
@@ -8,10 +8,14 @@ from astropy.time import Time
 from astropy.tests.helper import remote_data
 from astropy.utils.data import clear_download_cache
 from astropy.utils import iers
+from astropy.tests.helper import pytest
 
-from ..utils import (download_IERS_A, IERS_A_in_cache, get_IERS_A_or_workaround,
-                     BACKUP_Time_get_delta_ut1_utc, stride_array)
+from ..utils import (download_IERS_A, IERS_A_in_cache,
+                     get_IERS_A_or_workaround, BACKUP_Time_get_delta_ut1_utc,
+                     stride_array, time_grid_from_range)
+
 from ..exceptions import OldEarthOrientationDataWarning
+
 
 @remote_data
 def test_iers_download(monkeypatch, recwarn):
@@ -34,14 +38,30 @@ def test_iers_download(monkeypatch, recwarn):
 
     download_IERS_A()
 
-    #now test that it actually works post-IERS A download:
+    # now test that it actually works post-IERS A download:
     nowplusoneyear.ut1
 
 arr10 = np.arange(10)
+
+
 def test_stride_array():
-    stride10by5 = stride_array(arr10,5)
-    assert len(stride10by5)==6
+    stride10by5 = stride_array(arr10, 5)
+    assert len(stride10by5) == 6
+
 
 def test_stride_floats():
-    arr_float = np.asarray(arr10,float)
-    stride10by3 = stride_array(arr_float,3)
+    arr_float = np.asarray(arr10, float)
+    stride10by3 = stride_array(arr_float, 3)
+
+
+def test_time_grid_from_range():
+    times2 = ['2010-01-01 00:00:00', '2010-01-01 01:00:10']
+    times3 = ['2010-01-01 00:00:00', '2010-01-01 01:00:00',
+              '2010-01-01 03:00:00']
+    tgrid = time_grid_from_range(Time(times2))
+    assert len(tgrid) == 3
+    assert np.all(tgrid == Time(['2010-01-01 00:00:00', '2010-01-01 00:30:00',
+                                 '2010-01-01 01:00:00']))
+
+    with pytest.raises(ValueError):
+        time_grid_from_range(Time(times3))

--- a/astroplan/tests/test_utils.py
+++ b/astroplan/tests/test_utils.py
@@ -60,8 +60,9 @@ def test_time_grid_from_range():
               '2010-01-01 03:00:00']
     tgrid = time_grid_from_range(Time(times2))
     assert len(tgrid) == 3
-    assert np.all(tgrid == Time(['2010-01-01 00:00:00', '2010-01-01 00:30:00',
-                                 '2010-01-01 01:00:00']))
+    assert np.all(tgrid.iso == Time(['2010-01-01 00:00:00',
+                                     '2010-01-01 00:30:00',
+                                     '2010-01-01 01:00:00']))
 
     with pytest.raises(ValueError):
         time_grid_from_range(Time(times3))

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -148,10 +148,12 @@ def time_grid_from_range(time_range, time_resolution=0.5*u.hour):
     times : `~astropy.time.Time`
         Linearly-spaced sequence of times
     """
-    if len(time_range) != 2:
+    try:
+        start_time, end_time = time_range
+    except ValueError:
         raise ValueError("time_range should have a length of 2: lower and "
                          "upper bounds on the time sequence.")
-    return Time(np.arange(time_range[0].jd, time_range[1].jd,
+    return Time(np.arange(start_time.jd, end_time.jd,
                           time_resolution.to(u.day).value), format='jd')
 
 

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -13,7 +13,7 @@ from astropy.time import Time
 import astropy.units as u
 from astropy.utils.data import (_get_download_cache_locs, CacheMissingWarning,
                                 _open_shelve)
-from astropy.coordinates import EarthLocation, Longitude, Latitude
+from astropy.coordinates import EarthLocation
 
 # Package
 from .exceptions import OldEarthOrientationDataWarning
@@ -148,6 +148,9 @@ def time_grid_from_range(time_range, time_resolution=0.5*u.hour):
     times : `~astropy.time.Time`
         Linearly-spaced sequence of times
     """
+    if len(time_range) != 2:
+        raise ValueError("time_range should have a length of 2: lower and "
+                         "upper bounds on the time sequence.")
     return Time(np.arange(time_range[0].jd, time_range[1].jd,
                           time_resolution.to(u.day).value), format='jd')
 


### PR DESCRIPTION
This is to address the issue that came up in the astropy mailing list (time_range parameter was used rather than times, and thus silently only the first two grid elements were used only when calculating the constraint).

Probably some documentation improvement would be a better long term solution, but I'll leave that for someone else.
