### PR TITLE
Small documentation fixes that should clear up some test failures

### DIFF
--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -32,7 +32,7 @@ class ObservingBlock(object):
         """
         Parameters
         ----------
-        target : `~astroplan.FixedTarget'
+        target : `~astroplan.FixedTarget`
             Target to observe
 
         duration : `~astropy.units.Quantity`
@@ -225,7 +225,7 @@ class Schedule(object):
 
     def __init__(self, start_time, end_time, constraints=None):
         """
-        Parameters:
+        Parameters
         -----------
         start_time : `~astropy.time.Time`
             The starting time of the schedule; the start of your
@@ -360,7 +360,7 @@ class Slot(object):
 
     def __init__(self, start_time, end_time):
         """
-        Parameters:
+        Parameters
         -----------
         start_time : `~astropy.time.Time`
             The starting time of the slot


### PR DESCRIPTION
Two tests are failing because of these sphinx documentation errors. This should clean up a lot of the failures on different PRs except for the tests using numpy prerelease and astropy dev.