### PR TITLE
Use mock machinery for remote-data='none'

### DIFF
--- a/astroplan/conftest.py
+++ b/astroplan/conftest.py
@@ -72,5 +72,6 @@ def pytest_configure(config):
         # config.option.mpl_baseline_path = 'astroplan/plots/tests/baseline_images'
 
     # Activate remote data mocking if the `--remote-data` option isn't used:
-    if not config.getoption('remote_data'):
+    if (not config.getoption('remote_data')
+            or config.getvalue('remote_data') == 'none'):
         _mock_remote_data()


### PR DESCRIPTION
Remote data got values in astropy 1.3, thus we need to check for that and use the mock machinery if remote-data='none'

This solves most of the issues we see with astropy stable here #278 #263 

@bmorris3 - This should also be merged asap with the other bugfixes, so only the one broadcasting issue remains.