### PR TITLE
Fix broadcasting by using vector SkyCoords internally [WIP]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,11 @@ matrix:
         # plot_directive in sphinx needs them
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES='pytz matplotlib nose wcsaxes astroquery'
+               CONDA_DEPENDENCIES='pytz matplotlib nose astroquery'
                PIP_DEPENDENCIES='pytest-mpl'
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES='pytz matplotlib nose wcsaxes astroquery'
+               CONDA_DEPENDENCIES='pytz matplotlib nose astroquery'
                PIP_DEPENDENCIES='pytest-mpl'
 
         # Try all python versions with the latest numpy

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
         - CONDA_DEPENDENCIES='pytz'
         - PIP_DEPENDENCIES=''
         - SETUP_CMD='test -V'
-        - CONDA_CHANNELS='astropy'
+        - CONDA_CHANNELS='astropy conda-forge'
 
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.3 (unreleased)
 ----------------
 
-- No changes yet
+- Internal changes to the way calculations are done means that astropy>=1.3 is required [#285]
 
 0.2 (2016-09-20)
 ------------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
                         # to the matrix section.
       CONDA_DEPENDENCIES: "pytz matplotlib nose"
       PIP_DEPENDENCIES: "pyephem pytest-mpl"
-      CONDA_CHANNELS: "astropy"
+      CONDA_CHANNELS: "astropy conda-forge"
 
   matrix:
 

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -399,7 +399,7 @@ class AtNightConstraint(Constraint):
                     observer.pressure = 0
 
                 # find solar altitude at these times
-                altaz = observer.altaz(times, get_sun(times))
+                altaz = observer.altaz(times, get_sun(times), grid=False)
                 altitude = altaz.alt
                 # cache the altitude
                 observer._altaz_cache[aakey] = dict(times=times,
@@ -442,7 +442,7 @@ class SunSeparationConstraint(Constraint):
         self.max = max
 
     def compute_constraint(self, times, observer, targets):
-        sunaltaz = observer.altaz(times, get_sun(times))
+        sunaltaz = observer.altaz(times, get_sun(times), grid=False)
         target_coos = [target.coord if hasattr(target, 'coord') else target
                        for target in targets]
         target_altazs = [observer.altaz(times, coo) for coo in target_coos]

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -11,6 +11,8 @@ from astropy.coordinates import (EarthLocation, SkyCoord, AltAz, get_sun,
                                  get_moon, Angle, Latitude, Longitude,
                                  UnitSphericalRepresentation)
 from astropy.extern.six import string_types
+from astropy.utils import isiterable
+from astropy.utils.compat.numpy import broadcast_to
 import astropy.units as u
 from astropy.time import Time
 from astropy.utils import isiterable
@@ -20,6 +22,8 @@ import pytz
 # Package
 from .exceptions import TargetNeverUpWarning, TargetAlwaysUpWarning
 from .moon import moon_illumination, moon_phase_angle
+from .target import get_skycoord
+
 
 __all__ = ["Observer", "MAGIC_TIME"]
 
@@ -64,6 +68,14 @@ def _generate_24hr_grid(t0, start, end, N, for_deriv=False):
     else:
         time_grid = np.linspace(start, end, N)*u.day
 
+    # broadcast so grid is first index, and remaining shape of t0
+    # falls in later indices. e.g. if t0 is shape (10), time_grid
+    # will be shape (N, 10). If t0 is shape (5, 2), time_grid is (N, 5, 2)
+    while time_grid.ndim <= t0.ndim:
+        time_grid = time_grid[:, np.newaxis]
+    # we want to avoid 1D grids since we always want to broadcast against targets
+    if time_grid.ndim == 1:
+        time_grid = time_grid[:, np.newaxis]
     return t0 + time_grid
 
 
@@ -336,54 +348,31 @@ class Observer(object):
 
         return Time(date_time, location=self.location)
 
-    def _transform_target_list_to_altaz(self, times, targets):
-        """
-        Workaround for transforming a list of coordinates ``targets`` to
-        altitudes and azimuths.
+    def _is_broadcastable(self, shp1, shp2):
+        """Test if two shape tuples are broadcastable"""
+        if shp1 == shp2:
+            return True
+        for a, b in zip(shp1[::-1], shp2[::-1]):
+            if a == 1 or b == 1 or a == b:
+                pass
+            else:
+                return False
+        return True
 
-        Parameters
-        ----------
-        times : `~astropy.time.Time` or list of `~astropy.time.Time` objects
-            Time of observation
+    def _broadcast_targets_times(self, time, target):
+        # make sure we have a non-scalar time
+        if not isinstance(time, Time):
+            time = Time(time)
 
-        targets : `~astropy.coordinates.SkyCoord` or list of `~astropy.coordinates.SkyCoord` objects
-            List of target coordinates
+        # convert any kind of target argument to non-scalar SkyCoord
+        target = get_skycoord(target)
 
-        Returns
-        -------
-        altitudes : list
-            List of altitudes for each target, at each time
-        """
-        if times.isscalar:
-            times = Time([times])
-
-        if not isinstance(targets, list) and targets.isscalar:
-            targets = [targets]
-
-        targets_is_unitsphericalrep = [x.data.__class__ is
-                                       UnitSphericalRepresentation for x in targets]
-        if all(targets_is_unitsphericalrep) or not any(targets_is_unitsphericalrep):
-            repeated_times = np.tile(times, len(targets))
-            ra_list = Longitude([x.icrs.ra for x in targets])
-            dec_list = Latitude([x.icrs.dec for x in targets])
-            repeated_ra = np.repeat(ra_list, len(times))
-            repeated_dec = np.repeat(dec_list, len(times))
-            inner_sc = SkyCoord(ra=repeated_ra, dec=repeated_dec)
-            target_SkyCoord = SkyCoord(inner_sc.data.represent_as(UnitSphericalRepresentation),
-                                       representation=UnitSphericalRepresentation)
-            transformed_coord = target_SkyCoord.transform_to(AltAz(location=self.location,
-                                                                   obstime=repeated_times))
-        else:
-            # TODO: This is super slow.
-            repeated_times = np.tile(times, len(targets))
-            repeated_targets = np.repeat(targets, len(times))
-            target_SkyCoord = SkyCoord(SkyCoord(repeated_targets).data.represent_as(
-                                       UnitSphericalRepresentation),
-                                       representation=UnitSphericalRepresentation)
-
-            transformed_coord = target_SkyCoord.transform_to(AltAz(location=self.location,
-                                                                   obstime=repeated_times))
-        return transformed_coord
+        if not self._is_broadcastable(target.shape, time.shape):
+            # now we broadcast the targets array so that the first index
+            # iterates over targets, any other indices over times
+            while target.ndim <= time.ndim:
+                target = target[:, np.newaxis]
+        return time, target
 
     def altaz(self, time, target=None, obswl=None):
         """
@@ -437,8 +426,8 @@ class Observer(object):
 
         >>> target_altaz = apo.altaz(time, target) # doctest: +SKIP
         """
-        if not isinstance(time, Time):
-            time = Time(time)
+        if target is not None:
+            time, target = self._broadcast_targets_times(time, target)
 
         altaz_frame = AltAz(location=self.location, obstime=time,
                             pressure=self.pressure, obswl=obswl,
@@ -448,24 +437,7 @@ class Observer(object):
             # Return just the frame
             return altaz_frame
         else:
-            # If target is a list of targets:
-            if isiterable(target) and not isinstance(target, SkyCoord):
-                get_coord = lambda x: x.coord if hasattr(x, 'coord') else x
-                transformed_coords = self._transform_target_list_to_altaz(time,
-                                                                          list(map(get_coord, target)))
-                n_targets = len(target)
-                new_shape = (n_targets, int(len(transformed_coords)/n_targets))
-
-                for comp in transformed_coords.data.components:
-                    getattr(transformed_coords.data, comp).resize(new_shape)
-                return transformed_coords
-
-            # If target is a FixedTarget or a SkyCoord:
-            if hasattr(target, 'coord'):
-                coordinate = target.coord
-            else:
-                coordinate = target
-            return coordinate.transform_to(altaz_frame)
+            return target.transform_to(altaz_frame)
 
     def parallactic_angle(self, time, target):
         """
@@ -493,17 +465,7 @@ class Observer(object):
         .. [1] https://en.wikipedia.org/wiki/Parallactic_angle
 
         """
-        if not isinstance(time, Time):
-            time = Time(time)
-
-        if isiterable(target):
-            get_coord = lambda x: x.coord if hasattr(x, 'coord') else x
-            coordinate = SkyCoord(list(map(get_coord, target)))
-        else:
-            if hasattr(target, 'coord'):
-                coordinate = target.coord
-            else:
-                coordinate = target
+        time, coordinate = self._broadcast_targets_times(time, target)
 
         # Eqn (14.1) of Meeus' Astronomical Algorithms
         LST = time.sidereal_time('mean', longitude=self.location.longitude)
@@ -527,9 +489,12 @@ class Observer(object):
         Parameters
         ----------
         t : `~astropy.time.Time`
-            Grid of times
+            Grid of N times, any shape. Search grid along first axis, e.g (N, ...)
         alt : `~astropy.units.Quantity`
             Grid of altitudes
+            Depending on broadcasting we either have ndim >=3 and
+            M targets along first axis, e.g (M, N, ...), or
+            ndim = 2 and targets/times in last axis
         rise_set : {"rising",  "setting"}
             Calculate either rising or setting across the horizon
         horizon : float
@@ -540,61 +505,88 @@ class Observer(object):
         Returns
         -------
         Returns the lower and upper limits on the time and altitudes
-        of the horizon crossing.
+        of the horizon crossing. The altitude limits have shape (M, ...) and the
+        time limits have shape (...). These arrays aresuitable for interpolation
+        to find the horizon crossing time.
         """
-        alt = np.atleast_2d(Latitude(alt))
-        n_targets = alt.shape[0]
+        # handle different cases by enforcing standard shapes on
+        # the altitude grid
+        finesse_time_indexes = False
+        if alt.ndim == 1:
+            raise ValueError('Must supply more at least a 2D grid of altitudes')
+        elif alt.ndim == 2:
+            # TODO: this test for ndim=2 doesn't work. if times is e.g (2,5)
+            # then alt will have ndim=3, but shape (100, 2, 5) so grid
+            # is in first index...
+            ntargets = alt.shape[1]
+            ngrid = alt.shape[0]
+            unit = alt.unit
+            alt = broadcast_to(alt, (ntargets, ngrid, ntargets)).T
+            alt = alt*unit
+            extra_dimension_added = True
+            if t.shape[1] == 1:
+                finesse_time_indexes = True
+        else:
+            extra_dimension_added = False
+        output_shape = (alt.shape[0],) + alt.shape[2:]
 
         if rise_set == 'rising':
             # Find index where altitude goes from below to above horizon
-            condition = (alt[:, :-1] < horizon) * (alt[:, 1:] > horizon)
+            condition = (alt[:, :-1, ...] < horizon) * (alt[:, 1:, ...] > horizon)
         elif rise_set == 'setting':
             # Find index where altitude goes from above to below horizon
-            condition = (alt[:, :-1] > horizon) * (alt[:, 1:] < horizon)
+            condition = (alt[:, :-1, ...] > horizon) * (alt[:, 1:, ...] < horizon)
 
-        target_inds, time_inds = np.nonzero(condition)
+        noncrossing_indices = np.count_nonzero(condition, axis=1) < 1
+        alt_lims1 = u.Quantity(np.zeros(output_shape), unit=u.deg)
+        alt_lims2 = u.Quantity(np.zeros(output_shape), unit=u.deg)
+        jd_lims1 = np.zeros(output_shape)
+        jd_lims2 = np.zeros(output_shape)
+        if np.any(noncrossing_indices):
+            for target_index in set(np.where(noncrossing_indices)[0]):
+                warnmsg = ('Target with index {} does not cross horizon={} within '
+                           '24 hours'.format(target_index, horizon))
+                if (alt[target_index, ...] > horizon).all():
+                    warnings.warn(warnmsg, TargetAlwaysUpWarning)
+                else:
+                    warnings.warn(warnmsg, TargetNeverUpWarning)
 
-        if np.count_nonzero(condition) < n_targets:
-            target_inds, _ = np.nonzero(condition)
-            noncrossing_target_ind = np.setdiff1d(np.arange(n_targets),
-                                                  target_inds,
-                                                  assume_unique=True)  # [0]
+            alt_lims1[np.nonzero(noncrossing_indices)] = np.nan
+            alt_lims2[np.nonzero(noncrossing_indices)] = np.nan
+            jd_lims1[np.nonzero(noncrossing_indices)] = np.nan
+            jd_lims2[np.nonzero(noncrossing_indices)] = np.nan
 
-            warnmsg = ('Target(s) index {} does not cross horizon={} within '
-                       '24 hours'.format(noncrossing_target_ind, horizon))
+        before_indices = np.array(np.nonzero(condition))
+        # we want to add an vector like (0, 1, ...) to get after indices
+        array_to_add = np.zeros(before_indices.shape[0])[:, np.newaxis].astype(int)
+        array_to_add[1] = 1
+        after_indices = before_indices + array_to_add
 
-            if (alt[noncrossing_target_ind, :] > horizon).all():
-                warnings.warn(warnmsg, TargetAlwaysUpWarning)
-            else:
-                warnings.warn(warnmsg, TargetNeverUpWarning)
+        al1 = alt[tuple(before_indices)]
+        al2 = alt[tuple(after_indices)]
+        # slice the time in the same way, but delete the object index
+        before_time_index_tuple = np.delete(before_indices, 0, 0)
+        after_time_index_tuple = np.delete(after_indices, 0, 0)
+        if finesse_time_indexes:
+            before_time_index_tuple[1:] = 0
+            after_time_index_tuple[1:] = 0
+        tl1 = t[tuple(before_time_index_tuple)]
+        tl2 = t[tuple(after_time_index_tuple)]
 
-            # Fill in missing time with MAGIC_TIME
-            target_inds = np.insert(target_inds, noncrossing_target_ind,
-                                    noncrossing_target_ind)
-            time_inds = np.insert(time_inds.astype(float),
-                                  noncrossing_target_ind,
-                                  np.nan)
-        elif np.count_nonzero(condition) > n_targets:
-            old_target_inds = np.copy(target_inds)
-            old_time_inds = np.copy(time_inds)
+        alt_lims1[tuple(np.delete(before_indices, 1, 0))] = al1
+        alt_lims2[tuple(np.delete(before_indices, 1, 0))] = al2
+        jd_lims1[tuple(np.delete(before_indices, 1, 0))] = tl1.utc.jd
+        jd_lims2[tuple(np.delete(before_indices, 1, 0))] = tl2.utc.jd
 
-            time_inds = []
-            target_inds = []
-            for tgt, tm in zip(old_target_inds, old_time_inds):
-                if tgt not in target_inds:
-                    time_inds.append(tm)
-                    target_inds.append(tgt)
-            target_inds = np.array(target_inds)
-            time_inds = np.array(time_inds)
-
-        times = [t[int(i):int(i+2)] if not np.isnan(i) else np.nan for i in time_inds]
-        altitudes = [alt[int(i), int(j):int(j+2)] if not np.isnan(j) else np.nan
-                     for i, j in zip(target_inds, time_inds)]
-
-        return times, altitudes
+        if extra_dimension_added:
+            return (alt_lims1.diagonal(), alt_lims2.diagonal(),
+                    jd_lims1.diagonal(), jd_lims2.diagonal())
+        else:
+            return alt_lims1, alt_lims2, jd_lims1, jd_lims2
 
     @u.quantity_input(horizon=u.deg)
-    def _two_point_interp(self, times, altitudes, horizon=0*u.deg):
+    def _two_point_interp(self, jd_before, jd_after,
+                          alt_before, alt_after, horizon=0*u.deg):
         """
         Do linear interpolation between two ``altitudes`` at
         two ``times`` to determine the time where the altitude
@@ -602,11 +594,17 @@ class Observer(object):
 
         Parameters
         ----------
-        times : `~astropy.time.Time`
-            Two times for linear interpolation between
+        jd_before : `float`
+            JD(UTC) before crossing event
 
-        altitudes : array of `~astropy.units.Quantity`
-            Two altitudes for linear interpolation between
+        jd_after : `float`
+            JD(UTC) after crossing event
+
+        alt_before : `~astropy.units.Quantity`
+            altitude before crossing event
+
+        alt_after : `~astropy.units.Quantity`
+            altitude after crossing event
 
         horizon : `~astropy.units.Quantity`
             Solve for the time when the altitude is equal to
@@ -618,12 +616,10 @@ class Observer(object):
             Time when target crosses the horizon
 
         """
-        if not isinstance(times, Time):
-            return MAGIC_TIME
-        else:
-            slope = (altitudes[1] - altitudes[0])/(times[1].jd - times[0].jd)
-            return Time(times[1].jd - ((altitudes[1] - horizon)/slope).value,
-                        format='jd')
+        slope = (alt_after-alt_before)/((jd_after - jd_before)*u.d)
+        crossing_jd = (jd_after*u.d - ((alt_after - horizon)/slope))
+        crossing_jd[np.isnan(crossing_jd)] = u.d*MAGIC_TIME.jd
+        return np.squeeze(Time(crossing_jd, format='jd'))
 
     def _altitude_trig(self, LST, target):
         """
@@ -645,6 +641,7 @@ class Observer(object):
         alt : `~astropy.unit.Quantity`
             Array of altitudes
         """
+        LST, target = self._broadcast_targets_times(LST, target)
         alt = np.arcsin(np.sin(self.location.latitude.radian) *
                         np.sin(target.dec) +
                         np.cos(self.location.latitude.radian) *
@@ -688,11 +685,8 @@ class Observer(object):
         ret1 : `~astropy.time.Time`
             Time of rise/set
         """
-
         if not isinstance(time, Time):
             time = Time(time)
-
-        target_is_vector = isiterable(target)
 
         if prev_next == 'next':
             times = _generate_24hr_grid(time, 0, 1, N)
@@ -702,16 +696,10 @@ class Observer(object):
         altaz = self.altaz(times, target)
         altitudes = altaz.alt
 
-        time_limits, altitude_limits = self._horiz_cross(times, altitudes, rise_set,
-                                                         horizon)
-        if not target_is_vector:
-            return self._two_point_interp(time_limits[0], altitude_limits[0],
-                                          horizon=horizon)
-        else:
-            return Time([self._two_point_interp(time_limit, altitude_limit,
-                                                horizon=horizon)
-                         for time_limit, altitude_limit in
-                         zip(time_limits, altitude_limits)])
+        al1, al2, jd1, jd2 = self._horiz_cross(times, altitudes, rise_set,
+                                               horizon)
+        return self._two_point_interp(jd1, jd2, al1, al2,
+                                      horizon=horizon)
 
     def _calc_transit(self, time, target, prev_next, antitransit=False, N=150):
         """
@@ -745,10 +733,9 @@ class Observer(object):
         ret1 : `~astropy.time.Time`
             Time of transit/antitransit
         """
+        # TODO FIX BROADCASTING HERE
         if not isinstance(time, Time):
             time = Time(time)
-
-        target_is_vector = isiterable(target)
 
         if prev_next == 'next':
             times = _generate_24hr_grid(time, 0, 1, N, for_deriv=True)
@@ -763,25 +750,21 @@ class Observer(object):
             rise_set = 'setting'
 
         altaz = self.altaz(times, target)
-        if target_is_vector:
-            d_altitudes = [each_alt.diff() for each_alt in altaz.alt]
+        altitudes = altaz.alt
+        if altitudes.ndim > 2:
+            # shape is (M, N, ...) where M is targets and N is grid
+            d_altitudes = altitudes.diff(axis=1)
         else:
-            altitudes = altaz.alt
-            d_altitudes = altitudes.diff()
+            # shape is (N, M) where M is targets and N is grid
+            d_altitudes = altitudes.diff(axis=0)
 
         dt = Time((times.jd[1:] + times.jd[:-1])/2, format='jd')
 
         horizon = 0*u.degree  # Find when derivative passes through zero
-        time_limits, altitude_limits = self._horiz_cross(dt, d_altitudes,
-                                                         rise_set, horizon)
-        if not target_is_vector:
-            return self._two_point_interp(time_limits[0], altitude_limits[0],
-                                          horizon=horizon)
-        else:
-            return Time([self._two_point_interp(time_limit, altitude_limit,
-                                                horizon=horizon)
-                         for time_limit, altitude_limit in
-                         zip(time_limits, altitude_limits)])
+        al1, al2, jd1, jd2 = self._horiz_cross(dt, d_altitudes,
+                                               rise_set, horizon)
+        return self._two_point_interp(jd1, jd2, al1, al2,
+                                      horizon=horizon)
 
     def _determine_which_event(self, function, args_dict):
         """
@@ -819,19 +802,10 @@ class Observer(object):
                 return previous_event
 
         if which == 'nearest':
-            if isiterable(target):
-                return_times = []
-                for next_e, prev_e in zip(next_event, previous_event):
-                    if abs(time - prev_e) < abs(time - next_e):
-                        return_times.append(prev_e)
-                    else:
-                        return_times.append(next_e)
-                return Time(return_times)
-            else:
-                if abs(time - previous_event) < abs(time - next_event):
-                    return previous_event
-                else:
-                    return next_event
+            mask = abs(time - previous_event) < abs(time - next_event)
+            return Time(np.where(mask, previous_event.utc.jd,
+                        next_event.utc.jd), format='jd')
+
 
         raise ValueError('"which" kwarg must be "next", "previous" or '
                          '"nearest".')

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -1467,7 +1467,7 @@ class Observer(object):
             time = Time(time)
 
         moon = get_moon(time, location=self.location, ephemeris=ephemeris)
-        return self.altaz(time, moon)
+        return self.altaz(time, moon, grid=False)
 
     @u.quantity_input(horizon=u.deg)
     def target_is_up(self, time, target, horizon=0*u.degree, return_altaz=False):

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -574,7 +574,7 @@ class Observer(object):
             # Find index where altitude goes from above to below horizon
             condition = (alt[:, :-1, ...] > horizon) * (alt[:, 1:, ...] < horizon)
 
-        noncrossing_indices = np.count_nonzero(condition, axis=1) < 1
+        noncrossing_indices = np.sum(condition, axis=1, dtype=np.intp) < 1
         alt_lims1 = u.Quantity(np.zeros(output_shape), unit=u.deg)
         alt_lims2 = u.Quantity(np.zeros(output_shape), unit=u.deg)
         jd_lims1 = np.zeros(output_shape)

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -359,7 +359,7 @@ class Observer(object):
                 return False
         return True
 
-    def _preprocess_inputs(self, time, target, grid=True):
+    def _preprocess_inputs(self, time, target=None, grid=True):
         """
         Preprocess time and target inputs
 
@@ -383,6 +383,9 @@ class Observer(object):
         # make sure we have a non-scalar time
         if not isinstance(time, Time):
             time = Time(time)
+
+        if target is None:
+            return time, None
 
         # convert any kind of target argument to non-scalar SkyCoord
         target = get_skycoord(target)

--- a/astroplan/plots/finder.py
+++ b/astroplan/plots/finder.py
@@ -73,7 +73,7 @@ def plot_finder_image(target, survey='DSS', fov_radius=10*u.arcmin,
     Notes
     -----
     Dependencies:
-        In addition to Matplotlib, this function makes use of astroquery and WCSAxes.
+        In addition to Matplotlib, this function makes use of astroquery.
     """
 
     import matplotlib.pyplot as plt

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -137,7 +137,7 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
         style_kwargs = {}
     style_kwargs = dict(style_kwargs)
     style_kwargs.setdefault('linestyle', '-')
-    style_kwargs.setdefault('linewidth', '1.5')
+    style_kwargs.setdefault('linewidth', 1.5)
     style_kwargs.setdefault('fmt', '-')
 
     # Populate time window if needed.

--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -527,7 +527,7 @@ class SequentialScheduler(Scheduler):
             pre_filled = filled_times.reshape((2, 2))
         else:
             filled_times = Time(pre_filled.flatten())
-            pre_filled = filled_times.reshape((len(filled_times)/2, 2))
+            pre_filled = filled_times.reshape((int(len(filled_times)/2), 2))
         for b in blocks:
             if b.constraints is None:
                 b._all_constraints = self.constraints

--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -217,8 +217,7 @@ class TransitionBlock(object):
 
 class Schedule(object):
     """
-    An object that represents a schedule, consisting ofa list of
-    `~astroplan.scheduling.Slot` objects
+    An object that represents a schedule, consisting of a list of `~astroplan.scheduling.Slot` objects.
     """
     # as currently written, there should be no consecutive unoccupied slots
     # this should change to allow for more flexibility (e.g. dark slots, grey slots)
@@ -233,7 +232,7 @@ class Schedule(object):
         end_time : `~astropy.time.Time`
            The ending time of the schedule; the end of your
            observing window
-        constraints : sequence of `Constraint`s
+        constraints : sequence of `~astroplan.constraints.Constraint` s
            these are constraints that apply to the entire schedule
         """
         self.start_time = start_time

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -7,7 +7,7 @@ from abc import ABCMeta
 
 # Third-party
 import astropy.units as u
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import SkyCoord, ICRS, UnitSphericalRepresentation
 
 __all__ = ["Target", "FixedTarget", "NonFixedTarget"]
 

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -185,3 +185,77 @@ class NonFixedTarget(Target):
     """
     Placeholder for future function.
     """
+
+def get_skycoord(targets):
+    """
+    Return an `~astropy.coordinates.SkyCoord` object.
+
+    When performing calculations it is usually most efficient to have
+    a single `~astropy.coordinates.SkyCoord` object, rather than a
+    list of `FixedTarget` or `~astropy.coordinates.SkyCoord` objects.
+
+    This is a convenience routine to do that.
+
+    Parameters
+    -----------
+    targets : list, `~astropy.coordinates.SkyCoord`, `Fixedtarget`
+        either a single target or a list of targets
+
+    Returns
+    --------
+    coord : `~astropy.coordinates.SkyCoord`
+        a single SkyCoord object, which may be non-scalar
+    """
+    if not isinstance(targets, list):
+        return getattr(targets, 'coord', targets)
+
+    # get the SkyCoord object itself
+    coords = [getattr(target, 'coord', target) for target in targets]
+
+    # are all SkyCoordinate's in equivalent frames? If not, convert to ICRS
+    convert_to_icrs = not all([coord.frame.is_equivalent_frame(coords[0].frame) for coord in coords[1:]])
+
+    # we also need to be careful about handling mixtures of UnitSphericalRepresentations and others
+    targets_is_unitsphericalrep = [x.data.__class__ is
+                                   UnitSphericalRepresentation for x in coords]
+
+    longitudes = []
+    latitudes = []
+    distances = []
+    get_distances = not all(targets_is_unitsphericalrep)
+    if convert_to_icrs:
+        # mixture of frames
+        for coordinate in coords:
+            icrs_coordinate = coordinate.icrs
+            longitudes.append(icrs_coordinate.ra)
+            latitudes.append(icrs_coordinate.dec)
+            if get_distances:
+                distances.append(icrs_coordinate.distance)
+        frame = ICRS()
+    else:
+        # all the same frame, get the longitude and latitude names
+        lon_name, lat_name = [mapping.framename for mapping in
+                              coords[0].frame_specific_representation_info['spherical']]
+        frame = coords[0].frame
+        for coordinate in coords:
+            longitudes.append(getattr(coordinate, lon_name))
+            latitudes.append(getattr(coordinate, lat_name))
+            if get_distances:
+                distances.append(coordinate.distance)
+
+    # now let's deal with the fact that we may have a mixture of coords with distances and
+    # coords with UnitSphericalRepresentations
+    if all(targets_is_unitsphericalrep):
+        return SkyCoord(longitudes, latitudes, frame=frame)
+    elif not any(targets_is_unitsphericalrep):
+        return SkyCoord(longitudes, latitudes, distances, frame=frame)
+    else:
+        """
+        We have a mixture of coords with distances and without.
+        Since we don't know in advance the origin of the frame where further transformation
+        will take place, it's not safe to drop the distances from those coords with them set.
+
+        Instead, let's assign large distances to those objects with none.
+        """
+        distances = [distance if distance != 1 else 100*u.kpc for distance in distances]
+        return SkyCoord(longitudes, latitudes, distances, frame=frame)

--- a/astroplan/tests/test_target.py
+++ b/astroplan/tests/test_target.py
@@ -6,7 +6,8 @@ from numpy.testing import assert_raises
 
 # Third-party
 import astropy.units as u
-from astropy.coordinates import SkyCoord, GCRS
+from astropy.coordinates import SkyCoord, GCRS, ICRS
+from astropy.time import Time
 
 # Package
 from ..target import FixedTarget, get_skycoord

--- a/astroplan/tests/test_target.py
+++ b/astroplan/tests/test_target.py
@@ -2,16 +2,16 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from numpy.testing import assert_raises
-
 # Third-party
 import astropy.units as u
 from astropy.coordinates import SkyCoord, GCRS, ICRS
 from astropy.time import Time
+from astropy.tests.helper import pytest
 
 # Package
 from ..target import FixedTarget, get_skycoord
 from ..observer import Observer
+
 
 def test_FixedTarget_from_name():
     """
@@ -57,7 +57,8 @@ def test_get_skycoord():
 
     coo = get_skycoord(m31)
     assert coo.is_equivalent_frame(ICRS())
-    assert_raises(TypeError, len, coo)
+    with pytest.raises(TypeError) as exc_info:
+        len(coo)
 
     coo = get_skycoord([m31])
     assert coo.is_equivalent_frame(ICRS())

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,13 +14,12 @@ It requires Python 2.7 or 3.5+ (2.6 and 3.2 or earlier are not
 supported, 3.3 and 3.4 may work) as well as the following packages:
 
 * `Numpy`_
-* `Astropy`_ (v1.2 or later)
+* `Astropy`_ (v1.3 or later)
 * `pytz`_
 
 Optional packages:
 
 * `Matplotlib`_
-* `WCSAxes`_
 * `astroquery`_
 
 First-time Python users may want to consider an all-in-one Python installation

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -6,5 +6,4 @@
 .. _pytz: https://pypi.python.org/pypi/pytz/
 .. _pytest-mpl: https://pypi.python.org/pypi/pytest-mpl
 .. _Nose: https://nose.readthedocs.io
-.. _WCSAxes: https://wcsaxes.readthedocs.io
 .. _astroquery: https://astroquery.readthedocs.io

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,8 +1,7 @@
 numpy >= 1.6
 matplotlib
 Cython
-astropy-helpers
-astropy >= 1.2
+astropy >= 1.3
 pytz
 astroquery
-wcsaxes
+

--- a/docs/tutorials/plots.rst
+++ b/docs/tutorials/plots.rst
@@ -1121,9 +1121,8 @@ Finder Chart/Image
 `astroplan` includes a function for generating quick finder images from
 Python, `~astroplan.plots.plot_finder_image`, by querying for images from
 sky surveys centered on a `~astroplan.FixedTarget`. This function depends on
-`astroquery`_  (in addition
-to `Matplotlib`_ and `WCSAxes`_). In this example, we'll quickly make a finder image centered
-on The Crab Nebula (M1):
+`astroquery`_ (in addition to `Matplotlib`_). In this example, we'll quickly
+make a finder image centered on The Crab Nebula (M1):
 
 .. code-block:: python
 

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(name=PACKAGENAME,
       version=VERSION,
       description=DESCRIPTION,
       scripts=scripts,
-      install_requires=['numpy>=1.6', 'astropy>=1.2', 'pytz'],
+      install_requires=['numpy>=1.6', 'astropy>=1.3', 'pytz'],
       extras_require=dict(
           plotting=['matplotlib>=1.4'],
           docs=['sphinx_rtd_theme']


### PR DESCRIPTION
As described in #215, I think there's an argument for all internal calculations converting their arguments to ```Time``` and ```SkyCoord``` objects, which may be vector. This PR builds on the utility function in #215 and implements this functionality. It's a large change in the ```observer``` codebase, but outward facing functionality should be compatible with how it was before. However, there are so many unassociated test failures from other issues with astropy 1.3 it's hard to know, hence the WIP designation.

Once complete, this PR *could* fix remaining broadcasting issues with astropy 1.3 (e.g #282, #263, #272).

Some notes:

- This PR *requires* astropy 1.3 as a minimum version.
- ~~Although behaviour for scalar times and targets is unchanged, there is an improvement (IMO) in functionality for multiple times and targets. I briefly describe that here.~~

**This PR should give identical behaviour to the existing astroplan code, though the internals of the ```observer``` module have changed quite a lot. Please disregard the code samples below - I've left them in the comment for historical purposes**

First - for scalar objects:
```python
In [2]:  apo = Observer.at_site("APO")
In [3]:  times = Time(2457786.9048868627, format='jd')
In [4]:  m31 = coord.SkyCoord.from_name('M31')
In [5]:  apo.altaz(times, m31)
Out[5]: 
<SkyCoord (AltAz: obstime=2017-02-02 09:43:02.224949, location=(-1463969.3018517173, -5166673.342234327, 3434985.7120456537) m, pressure=0.0 hPa, temperature=0.0 deg_C, relative_humidity=0, obswl=1.0 micron): (az, alt) in deg
    ( 346.02166236, -13.98494769)>
```

However, if the times and targets are 1D and broadcastable, altaz and similar calcs will broadcast automatically:
```python
In [6]: ippeg = coord.SkyCoord.from_name('IP Peg')
In [7]: deneb = coord.SkyCoord.from_name('Deneb')
In [8]: times = times + np.linspace(-0.3, 0.3, 3)*u.d
In [9]: apo.altaz(times, [m31, ippeg, deneb])
Out[9]: 
<SkyCoord (AltAz: obstime=[datetime.datetime(2017, 2, 2, 2, 31, 2, 224949)
 datetime.datetime(2017, 2, 2, 9, 43, 2, 224949)
 datetime.datetime(2017, 2, 2, 16, 55, 2, 224949)], location=(-1463969.3018517173, -5166673.342234327, 3434985.7120456537) m, pressure=0.0 hPa, temperature=0.0 deg_C, relative_humidity=0, obswl=1.0 micron): (az, alt) in deg
    [( 297.48755926,  47.14479827), (   2.09385352, -38.68372101),
     (  52.36092567,  64.09699143)]>
```

also works with lists of ```FixedTargets```

```python
In [11]: apo.altaz(times, [FixedTarget(targ) for targ in [m31, ippeg, deneb]])
Out[11]: 
<SkyCoord (AltAz: obstime=[datetime.datetime(2017, 2, 2, 2, 31, 2, 224949)
 datetime.datetime(2017, 2, 2, 9, 43, 2, 224949)
 datetime.datetime(2017, 2, 2, 16, 55, 2, 224949)], location=(-1463969.3018517173, -5166673.342234327, 3434985.7120456537) m, pressure=0.0 hPa, temperature=0.0 deg_C, relative_humidity=0, obswl=1.0 micron): (az, alt) in deg
    [( 297.48755926,  47.14479827), (   2.09385352, -38.68372101),
     (  52.36092567,  64.09699143)]>
```

So far the same. But using vector skycoords internally adds functionality, since the ```horizon``` argument to the ```observer``` routines can be non-scalar and it will work as long as you can broadcast the horizon and altaz results:

```python
In [12]: apo.target_is_up(times, [m31, ippeg, deneb], horizon=u.Quantity([50*u.deg, 0*u.deg, 20*u.deg]))
Out[12]: array([False, False,  True], dtype=bool)
In [13]: apo.target_is_up(times, [m31, ippeg, deneb])
Out[13]: array([ True, False,  True], dtype=bool)
```

Also, by manipulating the shape of the times and targets object you can create a grid of ```altaz``` at all times and targets, rather than broadcasting, e.g:

```python
In [19]: apo.altaz(times[:, np.newaxis], [m31, ippeg, deneb])
Out[19]: 
<SkyCoord (AltAz: obstime=[[datetime.datetime(2017, 2, 2, 2, 31, 2, 224949)
  datetime.datetime(2017, 2, 2, 2, 31, 2, 224949)
  datetime.datetime(2017, 2, 2, 2, 31, 2, 224949)]
 [datetime.datetime(2017, 2, 2, 9, 43, 2, 224949)
  datetime.datetime(2017, 2, 2, 9, 43, 2, 224949)
  datetime.datetime(2017, 2, 2, 9, 43, 2, 224949)]
 [datetime.datetime(2017, 2, 2, 16, 55, 2, 224949)
  datetime.datetime(2017, 2, 2, 16, 55, 2, 224949)
  datetime.datetime(2017, 2, 2, 16, 55, 2, 224949)]], location=(-1463969.3018517173, -5166673.342234327, 3434985.7120456537) m, pressure=0.0 hPa, temperature=0.0 deg_C, relative_humidity=0, obswl=1.0 micron): (az, alt) in deg
    [[( 297.48755926,  47.14479827), ( 277.5507293 ,  23.53321076),
      ( 319.5051457 ,   8.36398593)],
     [( 346.02166236, -13.98494769), (   2.09385352, -38.68372101),
      (  28.22799217,  -3.00973326)],
     [(  53.52265937,  21.03003458), (  84.15855299,  26.41118594),
      (  52.36092567,  64.09699143)]]>
```

Although I haven't timed the performance I suspect it will be faster than the old, non-vectorised code as well.

There are still some issues with using vector ```Times``` or ```SkyCoords``` with higher dimensionality - see TODO note in ```_horiz_cross```.
