### PR TITLE
Transitioner should return None when no transition needed

### DIFF
--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -849,7 +849,8 @@ class Transitioner(object):
                                  [oldblock.target, newblock.target])['altaz']
                 # TODO: make this [0] unnecessary by fixing _get_altaz to behave well in scalar-time case
                 sep = aaz[0].separation(aaz[1])[0]
-                components['slew_time'] = sep / self.slew_rate
+                if sep/self.slew_rate > 1 * u.second:
+                    components['slew_time'] = sep / self.slew_rate
 
         if self.instrument_reconfig_times is not None:
             components.update(self.compute_instrument_transitions(oldblock, newblock))


### PR DESCRIPTION
As outlined in the docstring for ```Transitioner```, it should return ```None``` when called with ```ObservingBlocks``` that require no transition. 

Failure to do this is causing the issues with astropy 1.3.1 mentioned in #294.

This PR makes a minor tweak to the ```Transitioner``` class so that if there is no instrument reconfiguration, and the target is identical (or the slew time is less than 1 second), the call to the ```Transition``` returns ```None```.