### PR TITLE
Remove numpy 1.7 and 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,10 +87,6 @@ matrix:
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.9
-        - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8
-        - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7
 
         # Try developer version of Numpy
         - os: linux

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -1668,14 +1668,11 @@ class Observer(object):
         current_time = Time.now() if time is None else time
         night_mask = self.is_night(current_time, horizon=horizon, obswl=obswl)
         sun_set_time = self.sun_set_time(current_time, which='next', horizon=horizon)
-        # workaround for NPY <= 1.8, otherwise np.where works even in scalar case
-        if current_time.isscalar:
-            start_time = current_time if night_mask else sun_set_time
-        else:
-            start_time = np.where(night_mask, current_time, sun_set_time)
-            # np.where gives us a list of start Times - convert to Time object
-            if not isinstance(start_time, Time):
-                start_time = Time(start_time)
+
+        start_time = np.where(night_mask, current_time, sun_set_time)
+        # np.where gives us a list of start Times - convert to Time object
+        if not isinstance(start_time, Time):
+            start_time = Time(start_time)
         end_time = self.sun_rise_time(start_time, which='next', horizon=horizon)
 
         return start_time, end_time


### PR DESCRIPTION
Support for numpy 1.7 and 1.8 as well as python 3.3 will be removed in astropy v2.0, thus it probably makes sense to remove support for them here, too.