### PR TITLE
Using system pytest rather than astropy bundled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
         - PIP_DEPENDENCIES=''
         - SETUP_CMD='test -V'
         - CONDA_CHANNELS='astropy conda-forge'
+        - ASTROPY_USE_SYSTEM_PYTEST=1
 
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ environment:
       CONDA_DEPENDENCIES: "pytz matplotlib nose"
       PIP_DEPENDENCIES: "pyephem pytest-mpl"
       CONDA_CHANNELS: "astropy conda-forge"
+      ASTROPY_USE_SYSTEM_PYTEST: 1
 
   matrix:
 

--- a/astroplan/plots/tests/test_sky.py
+++ b/astroplan/plots/tests/test_sky.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from astropy.tests.helper import pytest
+import pytest
 
 try:
     import matplotlib

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -7,7 +7,7 @@ import astropy.units as u
 from astropy.time import Time
 from astropy.coordinates import SkyCoord, get_sun, get_moon
 from astropy.utils import minversion
-from astropy.tests.helper import pytest
+import pytest
 
 from ..observer import Observer
 from ..target import FixedTarget

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -8,7 +8,7 @@ import datetime
 # Third-party
 import astropy.units as u
 from astropy.time import Time
-from astropy.tests.helper import pytest
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import pytz

--- a/astroplan/tests/test_target.py
+++ b/astroplan/tests/test_target.py
@@ -2,11 +2,12 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import pytest
+
 # Third-party
 import astropy.units as u
 from astropy.coordinates import SkyCoord, GCRS, ICRS
 from astropy.time import Time
-from astropy.tests.helper import pytest
 
 # Package
 from ..target import FixedTarget, get_skycoord

--- a/astroplan/tests/test_utils.py
+++ b/astroplan/tests/test_utils.py
@@ -3,12 +3,13 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
+import pytest
+
 from astropy import units as u
 from astropy.time import Time
 from astropy.tests.helper import remote_data
 from astropy.utils.data import clear_download_cache
 from astropy.utils import iers
-from astropy.tests.helper import pytest
 
 from ..utils import (download_IERS_A, IERS_A_in_cache,
                      get_IERS_A_or_workaround, BACKUP_Time_get_delta_ut1_utc,


### PR DESCRIPTION
Bundled pytest gets deprecated in astropy core in 2.0, so better to start using the system one.