### PR TITLE
Use the generic ci-helpers script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ matrix:
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+    - source ci-helpers/travis/setup_conda.sh
 
     # This is needed to make matplotlib plot testing work
     - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then


### PR DESCRIPTION
Using the generic script will allow us to put more generic stuff in there without code repetition, e.g. the checks for the custom tags and skipping the builds early.