### PR TITLE
Astropy V2 fix

### DIFF
--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -235,8 +235,13 @@ def get_skycoord(targets):
         frame = ICRS()
     else:
         # all the same frame, get the longitude and latitude names
-        mappings = coords[0].frame_specific_representation_info[SphericalRepresentation]
-        lon_name, lat_name = [mapping.framename for mapping in mappings]
+        try:
+            lon_name, lat_name = [mapping.framename for mapping in
+                                  coords[0].frame_specific_representation_info['spherical']]
+        except:
+            # from astropy v2.0, keys are classes
+            lon_name, lat_name = [mapping.framename for mapping in
+                                  coords[0].frame_specific_representation_info[UnitSphericalRepresentation]]
 
         frame = coords[0].frame
         for coordinate in coords:

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -237,12 +237,14 @@ def get_skycoord(targets):
     else:
         # all the same frame, get the longitude and latitude names
         try:
-            lon_name, lat_name = [mapping.framename for mapping in
-                                  coords[0].frame_specific_representation_info['spherical']]
-        except:
             # from astropy v2.0, keys are classes
             lon_name, lat_name = [mapping.framename for mapping in
                                   coords[0].frame_specific_representation_info[UnitSphericalRepresentation]]
+        except:
+            # whereas prior to that they were strings.
+            lon_name, lat_name = [mapping.framename for mapping in
+                                  coords[0].frame_specific_representation_info['spherical']]
+
 
         frame = coords[0].frame
         for coordinate in coords:

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -187,6 +187,7 @@ class NonFixedTarget(Target):
     Placeholder for future function.
     """
 
+
 def get_skycoord(targets):
     """
     Return an `~astropy.coordinates.SkyCoord` object.


### PR DESCRIPTION
There is an issue with astropy V2 and astroplan in that the keys of a SkyCoord's ```frame_specific_representation_info``` have changed from strings to classes.

This copes with that change. Sorry for the messy commit history. Perhaps they should all be sqaushed into one commit on merge?