### PR TITLE
Priority scheduler logic

### DIFF
--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -886,6 +886,7 @@ class PriorityScheduler(Scheduler):
             # insert away
             if tb_before and tb_before_already_exists:
                 self.schedule.change_slot_block(slot_index - 1, new_block=tb_before)
+
             elif tb_before:
                 self.schedule.insert_slot(tb_before.start_time, tb_before)
 
@@ -895,10 +896,12 @@ class PriorityScheduler(Scheduler):
                 b.constraints = self.constraints
             elif self.constraints is not None:
                 b.constraints = b.constraints + self.constraints
+
             self.schedule.insert_slot(new_start_time, b)
 
             if tb_after:
                 self.schedule.insert_slot(tb_after.start_time, tb_after)
+
             return True
         except ValueError as error:
             # this shouldn't ever happen

--- a/astroplan/tests/test_scheduling.py
+++ b/astroplan/tests/test_scheduling.py
@@ -150,7 +150,7 @@ def test_priority_scheduler():
                 schedule.observing_blocks[2].target == vega])
     # polaris and rigel both peak just before the start time
     assert schedule.slots[0].block.target == polaris
-    assert schedule.slots[2].block.target == rigel
+    assert schedule.slots[3].block.target == rigel
     # test that the scheduler does not error when called with a partially
     # filled schedule
     scheduler(blocks, schedule)

--- a/astroplan/tests/test_scheduling.py
+++ b/astroplan/tests/test_scheduling.py
@@ -150,7 +150,7 @@ def test_priority_scheduler():
                 schedule.observing_blocks[2].target == vega])
     # polaris and rigel both peak just before the start time
     assert schedule.slots[0].block.target == polaris
-    assert schedule.slots[3].block.target == rigel
+    assert schedule.slots[2].block.target == rigel
     # test that the scheduler does not error when called with a partially
     # filled schedule
     scheduler(blocks, schedule)


### PR DESCRIPTION
This PR is inspired by difficulties I had trying to use the priority scheduler to plan an observing run. I'll describe the challenges I faced first, then my proposed fix.

I was trying to observe eclipses of short-period (<90min) binaries; and schedule many short (~20 minute) OBs to coincide with eclipses. To ensure that the scheduler does not schedule OBs too close together for a viable transition, the ```PriorityScheduler``` assumes the maximum possible transition time, and evaluates the constraints over the total time needed for the observation *plus the transition*. 

This doesn't work in my case, since my eclipse constraint is only valid for a short while, and not during the transition. As a result, none of my observations are ever scheduled.

My solution is to evaluate constraints on an OB, only during the time slots needed for the observation. This does mean that we can no longer be sure that the transition will prevent scheduling. So I now loop over all the possible schedule slots, in reverse priority order and see if the OB will fit.

This has slowed down the scheduler a bit, but has made it more robust. 

This PR also contains some more minor changes: I've documented the routines a bit more clearly, and have added some logic to avoid getting consecutive ```TransitionBlocks```, instead replacing them with a  single ```TransitionBlock```.

This is a pretty big PR and will need careful review I guess. 

What do you think @bmorris3, @eteq ?

