### PR TITLE
Implement moon_rise_time/moon_set_time

### DIFF
--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -271,3 +271,25 @@ def get_skycoord(targets):
         """
         distances = [distance if distance != 1 else 100*u.kpc for distance in distances]
         return SkyCoord(longitudes, latitudes, distances, frame=frame)
+
+
+class SpecialObjectFlag(object):
+    """
+    Flag this object as a special non-fixed target, which has a ``get_*`` method
+    within astropy (like the Sun or Moon)
+    """
+    pass
+
+
+class SunFlag(SpecialObjectFlag):
+    """
+    Flag for a computation with the Sun
+    """
+    approx_sidereal_drift = 5 * u.min
+
+
+class MoonFlag(SpecialObjectFlag):
+    """
+    Flag for a computation with the Moon
+    """
+    approx_sidereal_drift = 60 * u.min

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -294,8 +294,8 @@ def test_docs_example():
                 Minimum acceptable separation between Vega and target. `None`
                 indicates no limit.
             """
-            self.min = min if min else 0*u.deg
-            self.max = max if max else 180*u.deg
+            self.min = min if min is not None else 0*u.deg
+            self.max = max if max is not None else 180*u.deg
 
         def compute_constraint(self, times, observer, targets):
             vega = SkyCoord(ra=279.23473479*u.deg, dec=38.78368896*u.deg)

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -184,6 +184,7 @@ def test_rise_set_transit_nearest_vector():
     assert transit_vector[1] == mira_trans
     assert transit_vector[2] == sirius_trans
 
+
 def print_pyephem_altaz(latitude, longitude, elevation, time, pressure,
                       target_coords):
     """
@@ -206,6 +207,7 @@ def print_pyephem_altaz(latitude, longitude, elevation, time, pressure,
     pyephem_azimuth = Longitude(np.degrees(pyephem_target.az)*u.degree)
     print(pyephem_altitude, pyephem_azimuth)
 
+
 def test_Observer_timezone_parser():
     lat = '+19:00:00'
     lon = '-155:00:00'
@@ -222,6 +224,7 @@ def test_Observer_timezone_parser():
                                             'and instances of pytz.timezone')
 
     assert obs2.timezone == obs3.timezone, ('Default timezone should be UTC')
+
 
 def test_parallactic_angle():
     """
@@ -323,7 +326,7 @@ def test_sunrise_sunset_equator():
 
     # Typical difference in this example between PyEphem and astroplan
     # with an atmosphere is <2 min
-    threshold_minutes = 8
+    threshold_minutes = 2
     assert (abs(pyephem_next_sunrise - astroplan_next_sunrise) <
             datetime.timedelta(minutes=threshold_minutes))
     assert (abs(pyephem_next_sunset - astroplan_next_sunset) <
@@ -358,8 +361,8 @@ def print_pyephem_sunrise_sunset():
     prev_sunrise = obs.previous_rising(ephem.Sun(), use_center=True)
     prev_sunset = obs.previous_setting(ephem.Sun(), use_center=True)
 
-    print(map(repr, [next_sunrise.datetime(), next_sunset.datetime(),
-                     prev_sunrise.datetime(), prev_sunset.datetime()]))
+    print(list(map(repr, [next_sunrise.datetime(), next_sunset.datetime(),
+                          prev_sunrise.datetime(), prev_sunset.datetime()])))
 
 
 def test_vega_rise_set_equator():
@@ -395,7 +398,7 @@ def test_vega_rise_set_equator():
 
     # Typical difference in this example between PyEphem and astroplan
     # with an atmosphere is <2 min
-    threshold_minutes = 8
+    threshold_minutes = 2
     assert (abs(pyephem_next_rise - astroplan_next_rise) <
             datetime.timedelta(minutes=threshold_minutes))
     assert (abs(pyephem_next_set - astroplan_next_set) <
@@ -440,7 +443,8 @@ def print_pyephem_vega_rise_set():
     prev_rising = obs.previous_rising(target).datetime()
     prev_setting = obs.previous_setting(target).datetime()
 
-    print(map(repr, [next_rising, next_setting, prev_rising, prev_setting]))
+    print(list(map(repr, [next_rising, next_setting, prev_rising,
+                          prev_setting])))
 
 
 def test_vega_sirius_rise_set_seattle():
@@ -481,8 +485,8 @@ def test_vega_sirius_rise_set_seattle():
     pyephem_sirius_set = datetime.datetime(1990, 1, 1, 20, 33, 42, 342885)
 
     # Typical difference in this example between PyEphem and astroplan
-    # with an atmosphere is <8 min
-    threshold_minutes = 8
+    # with an atmosphere is <2 min
+    threshold_minutes = 2
     assert (abs(pyephem_vega_rise - astroplan_vega_rise) <
             datetime.timedelta(minutes=threshold_minutes))
     assert (abs(pyephem_sirius_rise - astroplan_sirius_rise) <
@@ -536,8 +540,8 @@ def print_pyephem_vega_sirius_rise_set():
     sirius_next_rising = obs.next_rising(sirius).datetime()
     sirius_next_setting = obs.next_setting(sirius).datetime()
 
-    print(map(repr, [vega_next_rising, sirius_next_rising,
-                     vega_next_setting, sirius_next_setting]))
+    print(list(map(repr, [vega_next_rising, sirius_next_rising,
+                          vega_next_setting, sirius_next_setting])))
 
 
 def test_sunrise_sunset_equator_civil_twilight():
@@ -553,16 +557,16 @@ def test_sunrise_sunset_equator_civil_twilight():
     time = Time('2000-01-01 12:00:00')
     obs = Observer(location=location, pressure=pressure)
     # Manually impose horizon equivalent to civil twilight
-    horizon = -6*u.degree
+    horizon = -6 * u.degree
     astroplan_next_sunrise = obs.sun_rise_time(time, which='next',
-                                         horizon=horizon).datetime
+                                               horizon=horizon).datetime
     astroplan_next_sunset = obs.sun_set_time(time, which='next',
-                                       horizon=horizon).datetime
+                                             horizon=horizon).datetime
 
     astroplan_prev_sunrise = obs.sun_rise_time(time, which='previous',
-                                         horizon=horizon).datetime
+                                               horizon=horizon).datetime
     astroplan_prev_sunset = obs.sun_set_time(time, which='previous',
-                                       horizon=horizon).datetime
+                                             horizon=horizon).datetime
 
     # Run print_pyephem_sunrise_sunset_equator_civil_twilight() to compute
     # analogous result from PyEphem:
@@ -571,7 +575,7 @@ def test_sunrise_sunset_equator_civil_twilight():
     pyephem_prev_rise = datetime.datetime(2000, 1, 1, 5, 37, 4, 701708)
     pyephem_prev_set = datetime.datetime(1999, 12, 31, 18, 29, 1, 530987)
 
-    threshold_minutes = 8
+    threshold_minutes = 2
     assert (abs(pyephem_next_rise - astroplan_next_sunrise) <
             datetime.timedelta(minutes=threshold_minutes))
     assert (abs(pyephem_next_set - astroplan_next_sunset) <
@@ -610,8 +614,8 @@ def print_pyephem_sunrise_sunset_equator_civil_twilight():
     prev_sunset = obs.previous_setting(ephem.Sun(), use_center=True)
 
     pyephem_time_to_datetime_str = lambda t: repr(t.datetime())
-    print(map(pyephem_time_to_datetime_str, [next_sunrise, next_sunset,
-                                             prev_sunrise, prev_sunset]))
+    print(list(map(pyephem_time_to_datetime_str, [next_sunrise, next_sunset,
+                                                  prev_sunrise, prev_sunset])))
 
 
 def test_twilight_convenience_funcs():
@@ -652,7 +656,7 @@ def test_twilight_convenience_funcs():
         datetime.datetime(2000, 1, 1, 18, 55, 37, 864882),
         datetime.datetime(2000, 1, 1, 19, 21, 53, 213768))
 
-    threshold_minutes = 8
+    threshold_minutes = 2
     # Compare morning twilights
     assert (abs(astroplan_morning_civil - pyephem_morning_civil) <
             datetime.timedelta(minutes=threshold_minutes))
@@ -706,10 +710,10 @@ def print_pyephem_twilight_convenience_funcs():
     evening_astronomical = obs.next_setting(ephem.Sun(), use_center=True)
 
     pyephem_time_to_datetime_str = lambda t: repr(t.datetime())
-    print(map(pyephem_time_to_datetime_str, [morning_civil, morning_nautical,
-                                             morning_astronomical,
-                                             evening_civil, evening_nautical,
-                                             evening_astronomical]))
+    print(list(map(pyephem_time_to_datetime_str, [morning_civil, morning_nautical,
+                                                  morning_astronomical,
+                                                  evening_civil, evening_nautical,
+                                                  evening_astronomical])))
 
 
 def test_solar_transit():
@@ -749,7 +753,7 @@ def test_solar_transit():
     pyephem_prev_transit = datetime.datetime(1999, 12, 31, 12, 2, 48, 562755)
     pyephem_prev_antitransit = datetime.datetime(2000, 1, 1, 0, 3, 2, 918943)
 
-    threshold_minutes = 8
+    threshold_minutes = 5
     assert (abs(astroplan_next_transit - pyephem_next_transit) <
             datetime.timedelta(minutes=threshold_minutes))
     assert (abs(astroplan_next_antitransit - pyephem_next_antitransit) <
@@ -790,7 +794,7 @@ def test_solar_transit_convenience_methods():
     pyephem_prev_transit = datetime.datetime(1999, 12, 31, 12, 2, 48, 562755)
     pyephem_prev_antitransit = datetime.datetime(2000, 1, 1, 0, 3, 2, 918943)
 
-    threshold_minutes = 8
+    threshold_minutes = 5
     assert (abs(astroplan_next_noon - pyephem_next_transit) <
             datetime.timedelta(minutes=threshold_minutes))
     assert (abs(astroplan_next_midnight - pyephem_next_antitransit) <
@@ -828,8 +832,8 @@ def print_pyephem_solar_transit_noon():
     prev_antitransit = obs.previous_antitransit(ephem.Sun())
 
     pyephem_time_to_datetime_str = lambda t: repr(t.datetime())
-    print(map(pyephem_time_to_datetime_str, [next_transit, next_antitransit,
-                                             prev_transit, prev_antitransit]))
+    print(list(map(pyephem_time_to_datetime_str, [next_transit, next_antitransit,
+                                                  prev_transit, prev_antitransit])))
 
 
 def test_vega_sirius_transit_seattle():
@@ -863,7 +867,7 @@ def test_vega_sirius_transit_seattle():
 
     # Typical difference in this example between PyEphem and astroplan
     # with an atmosphere is <2 min
-    threshold_minutes = 8
+    threshold_minutes = 2
     assert (abs(pyephem_vega_transit - astroplan_vega_transit) <
             datetime.timedelta(minutes=threshold_minutes))
     assert (abs(pyephem_sirius_transit - astroplan_sirius_transit) <
@@ -908,7 +912,7 @@ def print_pyephem_vega_sirius_transit():
     vega_next_transit = obs.next_transit(vega).datetime()
     sirius_next_transit = obs.next_transit(sirius).datetime()
 
-    print(map(repr, [vega_next_transit, sirius_next_transit]))
+    print(list(map(repr, [vega_next_transit, sirius_next_transit])))
 
 
 def test_target_is_up():
@@ -969,7 +973,7 @@ def test_string_times():
 
     # Typical difference in this example between PyEphem and astroplan
     # with an atmosphere is <2 min
-    threshold_minutes = 8
+    threshold_minutes = 2
     assert (abs(pyephem_next_rise - astroplan_next_rise) <
             datetime.timedelta(minutes=threshold_minutes))
     assert (abs(pyephem_next_set - astroplan_next_set) <
@@ -1109,7 +1113,7 @@ def print_pyephem_moon_altaz():
     pe_obs.date = time.datetime
     pe_obs.pressure = 0
     moon.compute(pe_obs)
-    print(map(float, [moon.alt, moon.az]))
+    print(list(map(float, [moon.alt, moon.az])))
 
 
 def test_exceptions():
@@ -1145,6 +1149,7 @@ def test_exceptions():
     with pytest.raises(TypeError):
         Observer(location=EarthLocation(0, 0, 0), timezone=-6)
 
+
 def vectorize_timing(n_targets):
     """
     Calculate the rise time of ``n_targets`` targets, return the
@@ -1171,6 +1176,7 @@ def test_local_sidereal_time():
     pyephem_lst = 2.5005375428099104*u.rad
     assert_quantity_allclose(astroplan_lst, pyephem_lst, atol=0.01*u.deg)
 
+
 def print_pyephem_lst():
     time = Time('2005-02-03 00:00:00')
     import ephem
@@ -1182,6 +1188,7 @@ def print_pyephem_lst():
     pe_lst = Angle(pe_apo.sidereal_time(), unit=u.rad)
     return pe_lst
 
+
 def test_hour_angle():
     # TODO: Add tests for different targets/times with tools other than PyEphem
     time = Time('2005-02-03 00:00:00')
@@ -1192,8 +1199,9 @@ def test_hour_angle():
     lst = obs.local_sidereal_time(time)
     assert_quantity_allclose(hour_angle, lst, atol=0.001*u.deg)
 
+
 def test_tonight():
-    obs = Observer.at_site('subaru')
+    obs = Observer.at_site('Subaru')
     obs.height = 0 * u.m
 
     horizon = 0 * u.degree
@@ -1215,9 +1223,9 @@ def test_tonight():
         datetime.timedelta(minutes=threshold_minutes))
 
     assert (abs(midnight.datetime - during_night[0].datetime) <
-        datetime.timedelta(minutes=threshold_minutes))
+            datetime.timedelta(minutes=threshold_minutes))
     assert (abs(sunrise - during_night[1].datetime) <
-        datetime.timedelta(minutes=threshold_minutes))
+            datetime.timedelta(minutes=threshold_minutes))
 
     astro_sunset = Time('2016-08-08 06:13:00')
     horizon = -18 * u.degree
@@ -1228,4 +1236,65 @@ def test_tonight():
 
     # Get correct astro sunset if checking after civil sunset
     assert (abs(astro_sunset.datetime - during_twilight[0].datetime) <
-        datetime.timedelta(minutes=threshold_minutes))
+            datetime.timedelta(minutes=threshold_minutes))
+
+
+def print_pyephem_moon_rise_set():
+    """
+    To run:
+
+    python -c 'from astroplan.tests.test_observer import print_pyephem_moon_rise_set as f; f()'
+    """
+    lat = '42:00:00'
+    lon = '-70:00:00'
+    elevation = 0.0 * u.m
+    pressure = 0
+    time = Time('2017-10-07 12:00:00')
+
+    import ephem
+    obs = ephem.Observer()
+    obs.lat = lat
+    obs.lon = lon
+    obs.elevation = elevation
+    obs.date = time.datetime
+    obs.pressure = pressure
+    next_moonrise = obs.next_rising(ephem.Moon(), use_center=True)
+    next_moonset = obs.next_setting(ephem.Moon(), use_center=True)
+    prev_moonrise = obs.previous_rising(ephem.Moon(), use_center=True)
+    prev_moonset = obs.previous_setting(ephem.Moon(), use_center=True)
+
+    print(list(map(repr, [next_moonrise.datetime(), next_moonset.datetime(),
+                          prev_moonrise.datetime(), prev_moonset.datetime()])))
+
+
+def test_moon_rise_set():
+    pyephem_next_rise = datetime.datetime(2017, 10, 7, 23, 50, 24, 407018)
+    pyephem_next_set = datetime.datetime(2017, 10, 7, 12, 30, 30, 787116)
+    pyephem_prev_rise = datetime.datetime(2017, 10, 6, 23, 13, 43, 644455)
+    pyephem_prev_set = datetime.datetime(2017, 10, 6, 11, 20, 9, 340009)
+
+    time = Time('2017-10-07 12:00:00')
+    lat = '42:00:00'
+    lon = '-70:00:00'
+    elevation = 0.0 * u.m
+    pressure = 0 * u.bar
+    location = EarthLocation.from_geodetic(lon, lat, elevation)
+
+    obs = Observer(location=location)
+
+    astroplan_next_rise = obs.moon_rise_time(time, which='next')
+    astroplan_next_set = obs.moon_set_time(time, which='next')
+    astroplan_prev_rise = obs.moon_rise_time(time, which='previous')
+    astroplan_prev_set = obs.moon_set_time(time, which='previous')
+
+    threshold_minutes = 2
+    assert (abs(pyephem_next_rise - astroplan_next_rise.datetime) <
+            datetime.timedelta(minutes=threshold_minutes))
+    assert (abs(pyephem_next_set - astroplan_next_set.datetime) <
+            datetime.timedelta(minutes=threshold_minutes))
+    assert (abs(pyephem_prev_rise - astroplan_prev_rise.datetime) <
+            datetime.timedelta(minutes=threshold_minutes))
+    assert (abs(pyephem_prev_set - astroplan_prev_set.datetime) <
+            datetime.timedelta(minutes=threshold_minutes))
+
+

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -613,7 +613,6 @@ def print_pyephem_sunrise_sunset_equator_civil_twilight():
     prev_sunrise = obs.previous_rising(ephem.Sun(), use_center=True)
     prev_sunset = obs.previous_setting(ephem.Sun(), use_center=True)
 
-
     def pyephem_time_to_datetime_str(t): return repr(t.datetime())
     print(list(map(pyephem_time_to_datetime_str,
                    [next_sunrise, next_sunset, prev_sunrise, prev_sunset])))

--- a/docs/tutorials/constraints.rst
+++ b/docs/tutorials/constraints.rst
@@ -403,8 +403,8 @@ Here's our ``VegaSeparationConstraint`` implementation::
                 Minimum acceptable separation between Vega and target. `None`
                 indicates no limit.
             """
-            self.min = min if min else 0*u.deg
-            self.max = max if max else 180*u.deg
+            self.min = min if min is not None else 0*u.deg
+            self.max = max if max is not None else 180*u.deg
             self.boolean_constraint = boolean_constraint
 
         def compute_constraint(self, times, observer, targets):

--- a/docs/tutorials/summer_triangle.rst
+++ b/docs/tutorials/summer_triangle.rst
@@ -378,16 +378,13 @@ If you need to take the Moon into account when observing, you may want to know
 when it rises, sets, what phase it's in, etc. Let's first find out if the Moon
 is out during the time we defined earlier:
 
-.. warning::
-
-    ``moon_rise_time()`` and ``moon_set_time()`` have not yet been implemented,
-    but hopefully will be in the next version of astroplan.
-
 .. code-block:: python
 
-    >>> #subaru.moon_rise_time(time)
+    >>> subaru.moon_rise_time(time) # doctest: +SKIP
+    <Time object: scale='utc' format='jd' value=2457190.1696768994>
 
-    >>> #subaru.moon_set_time(time)
+    >>> subaru.moon_set_time(time) # doctest: +SKIP
+    <Time object: scale='utc' format='jd' value=2457189.684134357>
 
 We could also look at the Moon's alt/az coordinates:
 


### PR DESCRIPTION
This pull request implements two methods on the `Observer` object that previously raised a `NotImplementedError`. They are the `moon_rise_time` and `moon_set_time` methods, which follow the same call signature as the `sun_rise_time` and `target_rise_time` methods, just for the quickly moving moon. 

Before this PR, when calling `observer.sun_rise_time(time)`, the sun's sky coordinates were being calculated only once, at time `time`, and then the altitude of that _fixed_ coordinate was propagated forwards or backwards in time to approximate the Sun's motion throughout the day. Of course, the sun is slowly moving with respect to the celestial sphere throughout that 24 hour period, which can make a difference in rise/set times on the order of 3 minutes. 

The moon's apparent drift leads to a rise/set time offset of ~50 minutes, so I refactored the implementation of the rise/set/transit mechanics under-the-hood so that the rise/set/transit times of _moving_ objects (so far just the Sun and Moon) are treated properly. Here's a short outline of what "treated properly" means: 
* When `observer.sun_rise_time(time)` is called, the solar altitude is calculated over a grid of times spanning from `time` to `time + 24 hours + 3 minutes`, to account for the Sun potentially rising a bit later – this is meant to be similar to one sidereal day.
* When `observer.moon_rise_time(time)` is called, the lunar altitude is calculated over a grid of times spanning from `time` to `time + 24 hours + 60 minutes` to account for the Moon rising later. **Question:** I know that the sun rises ~50 min later each day at mid-latitudes. How much later could the moon rise at _any_ latitude?

* When `observer.target_rise_time(time, fixed_target)` is called, the old scheme is executed, where the target is fixed on the celestial sphere and only 24 hours need to be considered.

I've added some tests, and tweaked the tolerance in the tests against PyEphem to ensure that astroplan is getting better agreement with PyEphem than it used to. Before the sun rise/set times were consistent to within 8 min, but now they're all consistent to within 2 min.

***

**Opinions wanted:** In order to treat the sun and moon differently from `FixedTarget` objects, while still using the same rise/set API, I chose to introduce the class [`SpecialObjectFlag` and its subclasses `MoonFlag` and `SunFlag`](https://github.com/bmorris3/astroplan/blob/moon/astroplan/target.py#L266-L285), which get dropped into the `target` argument of [the workhorse function `observer._calc_riseset(time, target)`](https://github.com/bmorris3/astroplan/blob/moon/astroplan/observer.py#L696). These flags define approximate "drift times" for each object – 3 minutes, 60 minutes for Sun and Moon, respectively. 

You could imagine that every planet/minor planet/solar system object are "special" objects too. But since we don't yet have any concrete plans for implementing the `NonFixedTarget` class, I figured this is an acceptable drop-in solution to the sun/moon rise/set problem for now. Because the Sun and Moon _are_ special.