### PR TITLE
Dropping numpy 1.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,8 +86,6 @@ matrix:
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
-        - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.9
 
         # Try developer version of Numpy
         - os: linux

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -17,7 +17,7 @@ from astropy.time import Time
 import astropy.units as u
 from astropy.coordinates import get_body, get_sun, get_moon, SkyCoord
 from astropy import table
-from astropy.utils.compat.numpy import broadcast_to
+
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
 
@@ -276,7 +276,7 @@ class Constraint(object):
             b = as_strided(x, shape=shp2, strides=[0] * len(shp2))
             output_shape = np.broadcast(a, b).shape
             if output_shape != np.array(result).shape:
-                result = broadcast_to(result, output_shape)
+                result = np.broadcast_to(result, output_shape)
 
         return result
 

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -12,7 +12,6 @@ from astropy.coordinates import (EarthLocation, SkyCoord, AltAz, get_sun,
                                  UnitSphericalRepresentation)
 from astropy.extern.six import string_types
 from astropy.utils import isiterable
-from astropy.utils.compat.numpy import broadcast_to
 import astropy.units as u
 from astropy.time import Time
 import numpy as np
@@ -562,7 +561,7 @@ class Observer(object):
             ntargets = alt.shape[1]
             ngrid = alt.shape[0]
             unit = alt.unit
-            alt = broadcast_to(alt, (ntargets, ngrid, ntargets)).T
+            alt = np.broadcast_to(alt, (ntargets, ngrid, ntargets)).T
             alt = alt*unit
             extra_dimension_added = True
             if t.shape[1] == 1:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,7 +13,7 @@ Requirements
 It requires Python 2.7 or 3.5+ (2.6 and 3.2 or earlier are not
 supported, 3.3 and 3.4 may work) as well as the following packages:
 
-* `Numpy`_
+* `Numpy`_ (1.10 or later)
 * `Astropy`_ (v1.3 or later)
 * `pytz`_
 

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(name=PACKAGENAME,
       version=VERSION,
       description=DESCRIPTION,
       scripts=scripts,
-      install_requires=['numpy>=1.6', 'astropy>=1.3', 'pytz'],
+      install_requires=['numpy>=1.10', 'astropy>=1.3', 'pytz'],
       extras_require=dict(
           plotting=['matplotlib>=1.4'],
           docs=['sphinx_rtd_theme']


### PR DESCRIPTION
It appears that 1.7 and 1.8 was already been dropped, but hasn't been updated in the docs or setup.py.