### PR TITLE
Use consistent formatting for time representation (ISO)

### DIFF
--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -67,8 +67,8 @@ class ObservingBlock(object):
                                      '({0}, unscheduled) at'
                                      .format(self.target.name))
         else:
-            s = '({0}, {1} to {2}) at'.format(self.target.name, self.start_time,
-                                              self.end_time)
+            s = '({0}, {1} to {2}) at'.format(self.target.name, self.start_time.iso,
+                                              self.end_time.iso)
             return orig_repr.replace('object at', s)
 
     @property
@@ -190,7 +190,7 @@ class TransitionBlock(object):
         if self.start_time is None or self.end_time is None:
             return orig_repr.replace('object at', ' ({0}, unscheduled) at'.format(comp_info))
         else:
-            s = '({0}, {1} to {2}) at'.format(comp_info, self.start_time, self.end_time)
+            s = '({0}, {1} to {2}) at'.format(comp_info, self.start_time.iso, self.end_time.iso)
             return orig_repr.replace('object at', s)
 
     @property


### PR DESCRIPTION
When printing astropy Time objects, the scheduling code used inconsistent time formatting; some blocks would display with ISO formatting (from `start_time.iso` for example) others with JD formatting, i.e.

```
observing_blocks: [<astroplan.scheduling.ObservingBlock (NGC1807, 2018-02-25 06:00:00.267596 to 2018-02-25 06:12:40.267596) at 0x7f2b84118518>, <astroplan.scheduling.ObservingBlock (NGC1857, 2458174.845836489 to 2458174.8474568594) at 0x7f2b84118550>]
```

This PR adds `.iso` to the format strings in `scheduling.py` that did not already have ISO formatting. All Time objects in `scheduling.py` are now printed consistently. If astroplan wishes to use a different standard, that's fine and you can ignore this PR, but it should be self-consistent. 