### PR TITLE
Initilize score_array as Quantity

### DIFF
--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -137,14 +137,13 @@ class Scorer(object):
         start = self.schedule.start_time
         end = self.schedule.end_time
         times = time_grid_from_range((start, end), time_resolution)
-        score_array = np.ones((len(self.blocks), len(times)))
+        score_array = u.Quantity(np.ones((len(self.blocks), len(times))))
         for i, block in enumerate(self.blocks):
             # TODO: change the default constraints from None to []
             if block.constraints:
                 for constraint in block.constraints:
-                    applied_score = constraint(self.observer, block.target,
+                    score_array[i] *= constraint(self.observer, block.target,
                                                times=times)
-                    score_array[i] *= applied_score
         for constraint in self.global_constraints:
             score_array *= constraint(self.observer, self.targets, times,
                                       grid_times_targets=True)


### PR DESCRIPTION
```
global_constraints = [constraints.AltitudeConstraint(min=30*units.deg, boolean_constraint=True)]
```
works correctly. 

However, if I want to score objects by altitude, the docs suggest 

```
global_constraints = [constraints.AltitudeConstraint(min=30*units.deg, boolean_constraint=False)
```

This throws an exception. `create_score_array` calls `constraint()` to get the constraint value for every object at every time-step. For `boolean_constraint=False`, `constraint()` returns a Astropy.Quantity object (containing a `np.ndarray`). This is then multiplied by `score_array` in `create_score_array` which is initialized using `np.ones`. This is a type error (`np.ndarray *= Quantity`)

To fix this, we need to initialize `score_array` as a `Astropy.Quantity` object containing all ones. This now works for both boolean and non-boolean constraints. 