### PR TITLE
Have observability_table accept scalar time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.5 (unreleased)
 ----------------
 
+- ``observability_table`` now accepts scalars as ``time_range`` arguments, and
+  gives ``'time observable'`` in this case in the resulting table. [#350]
 
 0.4 (2017-10-23)
 ----------------

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -92,7 +92,6 @@ def test_observability_table():
 
     assert all(ttab['fraction of time observable'] == stab['fraction of time observable'])
     assert 'time observable' in stab.colnames
-    1/0
 
 
 def test_compare_altitude_constraint_and_observer():

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -83,6 +83,17 @@ def test_observability_table():
                                    time_range=time_range)
     np.testing.assert_allclose(obstab['always observable'], all_obs)
 
+    # try the scalar time_range case
+    ttab = observability_table(constraints, subaru, targets,
+                               time_range=(time_range[0] - 12*u.hour,
+                                           time_range[0] + 12*u.hour))
+    stab = observability_table(constraints, subaru, targets,
+                               time_range=time_range[0])
+
+    assert all(ttab['fraction of time observable'] == stab['fraction of time observable'])
+    assert 'time observable' in stab.colnames
+    1/0
+
 
 def test_compare_altitude_constraint_and_observer():
     time = Time('2001-02-03 04:05:06')


### PR DESCRIPTION
I've been using a pattern a lot that I think might be best implemented via a simple modification to `observability_table`.  When planning an observing run I often want to know "on a given night which objects are up for X time".  That's a bit awkward with the current observability table, because I care about actual time not just the fraction. 

The easy fix is to change it so that `time_range` can be a scalar, which means "the 24 hours surrounding this time", which then makes it easy to compute the time (it's just 24 hours * the fraction).  This then gives me a quick-and-easy way to determine "how long are my objects available given my constraints."

cc @bmorris3 