### PR TITLE
Fix test failure due to time comparisons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,6 @@
 0.5 (unreleased)
 ----------------
 
-- Fix test failures on newer versions of Astropy [#351]
-
 
 0.4 (2017-10-23)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.5 (unreleased)
 ----------------
 
+- Fix test failures on newer versions of Astropy [#351]
+
 
 0.4 (2017-10-23)
 ----------------

--- a/astroplan/tests/test_scheduling.py
+++ b/astroplan/tests/test_scheduling.py
@@ -83,9 +83,9 @@ def test_schedule_insert_slot():
     end_time = start + duration
     block = TransitionBlock.from_duration(duration)
     schedule.insert_slot(end_time - duration, block)
-    assert end_time - duration == start
+    assert (end_time - duration).jd == start.jd
     assert len(schedule.slots) == 2
-    assert schedule.slots[0].start == start
+    assert schedule.slots[0].start.jd == start.jd
 
 
 def test_schedule_change_slot_block():


### PR DESCRIPTION
I'm not sure exactly why this worked before... my instinct would have been that directly comparing `Time` objects like this is dangerous (you don't know for sure whether they're the same format, etc).  This work-around I think fixes the failure I'm seeing on Astropy 3.0 (and I think this also then fixes #342)