### PR TITLE
Fix error in to_table()

### DIFF
--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -299,7 +299,8 @@ class Schedule(object):
                 ra.append('')
                 dec.append('')
                 config.append('')
-        return Table([target_names, start_times, end_times, durations, ra, dec, config],
+        return Table([target_names, start_times, end_times, durations,
+                      u.Quantity(ra), u.Quantity(dec), config],
                      names=('target', 'start time (UTC)', 'end time (UTC)',
                             'duration (minutes)', 'ra', 'dec', 'configuration'))
 


### PR DESCRIPTION
I am using astropy 3.0.1 and numpy 1.14.3. Without this patch,
`schedule.to_table()` produces this exception:

    TypeError: only dimensionless scalar quantities can be converted to Python scalars