### PR TITLE
Access correct variable for longitude in EarthLocation

### DIFF
--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -506,7 +506,7 @@ class Observer(object):
         time, coordinate = self._preprocess_inputs(time, target, grid_times_targets)
 
         # Eqn (14.1) of Meeus' Astronomical Algorithms
-        LST = time.sidereal_time('mean', longitude=self.location.lon)
+        LST = time.sidereal_time('mean', longitude=self.location.longitude)
         H = (LST - coordinate.ra).radian
         q = np.arctan2(np.sin(H),
                        (np.tan(self.location.lat.radian) *
@@ -1736,7 +1736,7 @@ class Observer(object):
         if not isinstance(time, Time):
             time = Time(time)
 
-        return time.sidereal_time(kind, longitude=self.location.lon,
+        return time.sidereal_time(kind, longitude=self.location.longitude,
                                   model=model)
 
     def target_hour_angle(self, time, target, grid_times_targets=False):


### PR DESCRIPTION
In observer.py (and possibly elsewhere), it points to `self.location.lon` which is now incompatible with astropy, and should be changed to `self.location.longitude` instead. Tested this with the `local_sidereal_time` function which had given an error (`AttributeError: 'EarthLocation' object has no 'lon' member`). Changing both instances to `self.location.longitude` fixed the issue.