### PR TITLE
Replace astropy.extern.six with six

### DIFF
--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -9,7 +9,7 @@ import warnings
 # Third-party
 from astropy.coordinates import (EarthLocation, SkyCoord, AltAz, get_sun,
                                  get_moon, Angle, Longitude)
-from astropy.extern.six import string_types
+from six import string_types
 import astropy.units as u
 from astropy.time import Time
 import numpy as np


### PR DESCRIPTION
Replace `astropy.extern.six` as per the [deprecations in astropy 3.2](https://docs.astropy.org/en/stable/whatsnew/3.2.html#deprecated-renamed-removed-functionality).

Removes deprecation warnings from imports.