### PR TITLE
Adding `n_grid_points` parameter to rise/set/transit functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@
   Galactic point sources is an issue. [#413]
 
 
+- Add `N` keyword argument to rise/set/transit functions which allows users to
+  trade off precision for speed. [#424]
+
 0.5 (2019-07-08)
 ----------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,8 +15,8 @@
   Galactic point sources is an issue. [#413]
 
 
-- Add `N` keyword argument to rise/set/transit functions which allows users to
-  trade off precision for speed. [#424]
+- Add ``N`` keyword argument to rise/set/transit functions which allows users
+  to trade off precision for speed. [#424]
 
 0.5 (2019-07-08)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,8 +15,8 @@
   Galactic point sources is an issue. [#413]
 
 
-- Add ``N`` keyword argument to rise/set/transit functions which allows users
-  to trade off precision for speed. [#424]
+- Add ``n_grid_points`` keyword argument to rise/set/transit functions which
+  allows usersto trade off precision for speed. [#424]
 
 0.5 (2019-07-08)
 ----------------

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -24,3 +24,4 @@ We currently have the following tutorials:
    periodic
    constraints
    scheduling
+   speed

--- a/docs/tutorials/speed.rst
+++ b/docs/tutorials/speed.rst
@@ -1,0 +1,69 @@
+.. _speed:
+
+*********************
+Speeding up astroplan
+*********************
+
+Some users of astroplan may find it useful to trade-off a bit of precision
+in the rise/set/transit times of targets in exchange for computational
+efficiency. In this short tutorial, we show you how to speed up astroplan
+in exchange for a bit of time precision, which is especially useful when
+planning many observations over a long period of time.
+
+Rise/set/transit times
+======================
+
+The rise, set, and transit time methods on the `~astroplan.Observer` object
+take an optional keyword argument called ``N`` as of astroplan version 0.6
+(in earlier versions of astroplan, ``N`` is fixed to 150). To understand ``N``
+you first need to know how target rise/set/transit times
+are computed in astroplan.
+
+Astroplan computes rise/set times relative to a given reference time by
+computing the altitude of the target on a grid which spans a period of 24 hours
+before/after the reference time. The grid is then searched for
+horizon-crossings, and astroplan interpolates between the two nearest-to-zero
+altitudes to approximate the target rise/set times.
+
+The ``N`` keyword argument dictates the number of grid points on which to
+compute the target altitude. The larger the ``N``, the more precise the
+rise/set/transit time will be, but the operation also becomes more
+computationally expensive. As a general rule of thumb, if you choose ``N=150``
+your rise/set time precisions will be precise to better than one minute; this
+is the default if you don't specify ``N``. If you choose ``N=10`` you'll get
+significantly faster rise/set time computations, but your precision degrades to
+better than five minutes.
+
+Examples
+========
+
+Let's see some simple examples. We can compute a very accurate rise time for
+Sirius over Apache Point Observatory, by specifying ``N=1000``:
+
+.. code-block:: python
+
+    >>> from astroplan import Observer, FixedTarget
+    >>> from astropy.time import Time
+
+    >>> time = Time('2019-01-01 00:00')
+    >>> sirius = FixedTarget.from_name('Sirius')
+    >>> apo = Observer.at_site('APO')
+
+    >>> rise_time_accurate = apo.target_rise_time(time, sirius, N=1000)
+    >>> rise_time_accurate.iso  # doctest: +SKIP
+    '2019-01-01 01:52:13.393'
+
+That's the rise time computed on a grid of 1000 altitudes in a 24 hour period,
+so it should be very accurate. Now let's compute a lower precision, but much
+faster rise time, using ``N=10`` this time:
+
+.. code-block::
+
+    >>> rise_time_fast = apo.target_rise_time(time, sirius, N=10)
+    >>> rise_time_fast.iso  # doctest: +SKIP
+    '2019-01-01 01:54:09.946'
+
+You can see that the rise time returned by
+`~astroplan.Observer.target_rise_time` with ``N=10`` is only two minutes
+different from the prediction with ``N=1000``, so it looks like we haven't lost
+much precision despite the drastically different number of grid points.

--- a/docs/tutorials/speed.rst
+++ b/docs/tutorials/speed.rst
@@ -14,10 +14,10 @@ Rise/set/transit times
 ======================
 
 The rise, set, and transit time methods on the `~astroplan.Observer` object
-take an optional keyword argument called ``N`` as of astroplan version 0.6
-(in earlier versions of astroplan, ``N`` is fixed to 150). To understand ``N``
-you first need to know how target rise/set/transit times
-are computed in astroplan.
+take an optional keyword argument called ``n_grid_points`` as of astroplan
+version 0.6 (in earlier versions of astroplan, ``n_grid_points`` is fixed to
+150). To understand ``n_grid_points`` you first need to know how target
+rise/set/transit times are computed in astroplan.
 
 Astroplan computes rise/set times relative to a given reference time by
 computing the altitude of the target on a grid which spans a period of 24 hours
@@ -25,20 +25,20 @@ before/after the reference time. The grid is then searched for
 horizon-crossings, and astroplan interpolates between the two nearest-to-zero
 altitudes to approximate the target rise/set times.
 
-The ``N`` keyword argument dictates the number of grid points on which to
-compute the target altitude. The larger the ``N``, the more precise the
-rise/set/transit time will be, but the operation also becomes more
-computationally expensive. As a general rule of thumb, if you choose ``N=150``
-your rise/set time precisions will be precise to better than one minute; this
-is the default if you don't specify ``N``. If you choose ``N=10`` you'll get
-significantly faster rise/set time computations, but your precision degrades to
-better than five minutes.
+The ``n_grid_points`` keyword argument dictates the number of grid points on
+which to compute the target altitude. The larger the ``n_grid_points``, the
+more precise the rise/set/transit time will be, but the operation also becomes
+more computationally expensive. As a general rule of thumb, if you choose
+``n_grid_points=150`` your rise/set time precisions will be precise to better
+than one minute; this is the default if you don't specify ``n_grid_points``. If
+you choose ``n_grid_points=10`` you'll get significantly faster rise/set time
+computations, but your precision degrades to better than five minutes.
 
 Examples
 ========
 
 Let's see some simple examples. We can compute a very accurate rise time for
-Sirius over Apache Point Observatory, by specifying ``N=1000``:
+Sirius over Apache Point Observatory, by specifying ``n_grid_points=1000``:
 
 .. code-block:: python
 
@@ -49,21 +49,31 @@ Sirius over Apache Point Observatory, by specifying ``N=1000``:
     >>> sirius = FixedTarget.from_name('Sirius')
     >>> apo = Observer.at_site('APO')
 
-    >>> rise_time_accurate = apo.target_rise_time(time, sirius, N=1000)
+    >>> rise_time_accurate = apo.target_rise_time(time, sirius, n_grid_points=1000)
     >>> rise_time_accurate.iso  # doctest: +SKIP
     '2019-01-01 01:52:13.393'
 
 That's the rise time computed on a grid of 1000 altitudes in a 24 hour period,
-so it should be very accurate. Now let's compute a lower precision, but much
-faster rise time, using ``N=10`` this time:
+so it should be very accurate, but we can run the ``timeit`` function on the
+above code snippet to see how slow this is::
 
-.. code-block::
+    290 ms ± 4.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
 
-    >>> rise_time_fast = apo.target_rise_time(time, sirius, N=10)
+Now let's compute a lower precision, but much faster rise time, using ``N=10``
+this time:
+
+.. code-block:: python
+
+    >>> rise_time_fast = apo.target_rise_time(time, sirius, n_grid_points=10)
     >>> rise_time_fast.iso  # doctest: +SKIP
     '2019-01-01 01:54:09.946'
 
+And timing the above snippet, we find::
+
+    27.3 ms ± 709 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
+
 You can see that the rise time returned by
-`~astroplan.Observer.target_rise_time` with ``N=10`` is only two minutes
-different from the prediction with ``N=1000``, so it looks like we haven't lost
-much precision despite the drastically different number of grid points.
+`~astroplan.Observer.target_rise_time` with ``n_grid_points=10`` is only two
+minutes different from the prediction with ``n_grid_points=1000``, so it looks
+like we haven't lost much precision despite the drastically different number of
+grid points and an order-of-magnitude speedup.


### PR DESCRIPTION
**tl;dr**: you can speed up rise/set times by an order of magnitude in exchange for a few minutes of rise/set time precision, without changing anything fundamental about how astroplan/astropy compute rise/set times.

This PR implements the changes I suggested in #423, which I summarize briefly below. There are also several PEP8 compliance fixes throughout the docstrings on the Observer object. If merged, this PR supersedes #327.

The primary goal of this PR is to expose the `N` parameter, which has been lurking within the guts of the Observer object since its inception. Rise/set/transit times are computed using a grid search, which scans for horizon crossings over `N=150` times spread over 24 hours relative to the reference time supplied by the user. By throttling that parameter up or down, the user can simultaneously change the precision and speed of rise/set/transit calculations. `N~100` gives precision better than 1 min from the true rise/set/transit time, `N~10` gives precision better than 5 minutes and is about 10x faster. This fix is designed to address the common complaint that rise/set times are slow (#402, #423).

The default behavior of the functions remains unchanged. When not supplied by the user, `N=150` by default for all functions. Thus none of the tests need to change, and introducing this new optional kwarg won't change people's results in legacy code.

Still to do: 
* ~add narrative docs explaining the update~
* include plots in docs comparing precision at different `N`