### PR TITLE
Removing MAGIC_TIME variable in favor of masked Times

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,19 @@
 0.6 (unreleased)
 ----------------
 
+- Added documentation for reproducing MMTO sun rise/set times [#434]
+
+- Deprecation of ``MAGIC_TIME`` variable, which used to be returned for targets
+  that don't rise or set [#435]
+
+- Replace deprecated astroquery service [#431]
+
+- Fix for the broken IERS patch [#418, #425]
+
 - Add ``GalacticLatitudeConstraint`` to constrain the galactic latitudes of
   targets. This can be useful for planning surveys for which crowding due to
   Galactic point sources is an issue. [#413]
 
-- Fix for the broken IERS patch [#425]
 
 0.5 (2019-07-08)
 ----------------

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -27,10 +27,12 @@ __all__ = ["Observer"]
 
 MAGIC_TIME = Time(-999, format='jd')
 
+
 # Handle deprecated MAGIC_TIME variable
 def deprecation_wrap_module(mod, deprecated):
     """Return a wrapped object that warns about deprecated accesses"""
     deprecated = set(deprecated)
+
     class DeprecateWrapper(object):
         def __getattr__(self, attr):
             if attr in deprecated:
@@ -40,6 +42,7 @@ def deprecation_wrap_module(mod, deprecated):
             return getattr(mod, attr)
 
     return DeprecateWrapper()
+
 
 sys.modules[__name__] = deprecation_wrap_module(sys.modules[__name__],
                                                 deprecated=['MAGIC_TIME'])

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -17,7 +17,7 @@ from astropy.coordinates import (EarthLocation, Latitude, Longitude, SkyCoord,
 from astropy.tests.helper import assert_quantity_allclose
 
 # Package
-from ..observer import Observer, MAGIC_TIME
+from ..observer import Observer
 from ..target import FixedTarget
 from ..exceptions import TargetAlwaysUpWarning, TargetNeverUpWarning
 
@@ -1001,7 +1001,7 @@ def test_TargetAlwaysUpWarning(recwarn):
 
     w = recwarn.pop(TargetAlwaysUpWarning)
     assert issubclass(w.category, TargetAlwaysUpWarning)
-    assert no_time == MAGIC_TIME
+    assert no_time.mask
 
 
 def test_TargetNeverUpWarning(recwarn):
@@ -1017,7 +1017,7 @@ def test_TargetNeverUpWarning(recwarn):
 
     w = recwarn.pop(TargetNeverUpWarning)
     assert issubclass(w.category, TargetNeverUpWarning)
-    assert no_time == MAGIC_TIME
+    assert no_time.mask
 
 
 def test_mixed_rise_and_dont_rise():
@@ -1033,9 +1033,9 @@ def test_mixed_rise_and_dont_rise():
     with pytest.warns(TargetAlwaysUpWarning) as recwarn:
         rise_times = obs.target_rise_time(time, targets, which='next')
 
-    assert rise_times[1] == MAGIC_TIME
+    assert rise_times.mask[1]
 
-    targets_that_rise = np.array(targets)[rise_times != MAGIC_TIME]
+    targets_that_rise = np.array(targets)[~rise_times.mask]
     assert np.all([vega, sirius] == targets_that_rise)
 
     w = recwarn.pop(TargetAlwaysUpWarning)


### PR DESCRIPTION
Small API update, inspired by #398 and finally getting around to developing a more permanent fix for the temporary machinery implemented in https://github.com/astropy/astroplan/pull/34#issuecomment-128089175. **Note:** this PR will break backwards compatibility for an undocumented global variable of the observer module called `MAGIC_TIME`.

### Context 

In #34, we designed the rise/set time functions to return a `Time` object regardless of whether or not the target actually rises or sets. In order to represent times for targets that don't rise or set, we set the rise/set time to a "magic" value, stored in `astroplan.observer.MAGIC_TIME`, which was equivalent to `Time(-999, format='jd')`. 

After discussion in astropy/astropy#4032 and others, and an update to astropy in astropy/astropy#6028, it became possible to mask times in `Time` objects. Masked `Time` objects should replace the `MAGIC_TIME`s used to mask out nonsensical rise/set times in astroplan.

### Updates
* removes `MAGIC_TIME` from the astroplan default namespace
* replaces `MAGIC_TIME`s with masked `Time` objects in the rise/set functions and their tests
* makes accessible a legacy `MAGIC_TIME` variable, which now raises an `AstropyDeprecationWarning` when imported, via 
```python
from astroplan.observer import MAGIC_TIME
```

##### Testing

~The tests are likely to fail on this PR due to astropy/astroquery#1586.~