### PR TITLE
Different strategy for measuring the last date in the IERS table

### DIFF
--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -92,9 +92,16 @@ def _get_IERS_A_table(warn_update=14*u.day):
     if IERS_A_in_cache():
         table = iers.IERS_Auto.open()
         # Use polar motion flag to identify last observation before predictions
-        index_of_last_observation = ''.join(table['PolPMFlag_A']).index('IP')
-        time_of_last_observation = Time(table['MJD'][index_of_last_observation],
-                                        format='mjd')
+        if 'PolPMFlag_A' in table.colnames:
+            index_of_last_observation = ''.join(table['PolPMFlag_A']).index('IP')
+            time_of_last_observation = Time(table['MJD'][index_of_last_observation],
+                                            format='mjd')
+            
+        # If time of last observation is not available, set it equal to the
+        # final prediction in the table:
+        else:
+            time_of_last_observation = Time(table['MJD'].max(),
+                                            format='mjd')
         time_since_last_update = Time.now() - time_of_last_observation
 
         # If the IERS bulletin is more than `warn_update` days old, warn user

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -96,7 +96,7 @@ def _get_IERS_A_table(warn_update=14*u.day):
             index_of_last_observation = ''.join(table['PolPMFlag_A']).index('IP')
             time_of_last_observation = Time(table['MJD'][index_of_last_observation],
                                             format='mjd')
-            
+
         # If time of last observation is not available, set it equal to the
         # final prediction in the table:
         else:


### PR DESCRIPTION
[Seeking advice from: @mhvk @eteq @pllim]

Is this PR sufficient for measuring the age of an IERS table? In #436, we're getting an error when we download an old version of the IERS A table from `ftp://cddis.gsfc.nasa.gov/pub/products/iers/finals2000A.all` which appears to _not_ contain the `PolPMFlag_A` column. 

cc @tepickering and @bjweiner.

Fixes #436.