### PR TITLE
Avoid traceback when source is always up

### DIFF
--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -924,13 +924,20 @@ class Observer(object):
                 return previous_event
 
         if which == 'nearest':
-            if not (np.isfinite(previous_event.value) and
-                    np.isfinite(next_event.value)):
-                # always up?  Or some other case?
+            # Use some hacks to handle the non-rising/non-setting cases
+            try:
+                mask = abs(time - previous_event) < abs(time - next_event)
+            except TypeError:
+                # encountered if time is scalar & nan
                 return next_event
-            mask = abs(time - previous_event) < abs(time - next_event)
-            return Time(np.where(mask, previous_event.utc.jd,
-                                 next_event.utc.jd), format='jd')
+            ma = np.where(mask, previous_event.utc.jd, next_event.utc.jd)
+            # HACK: Time objects cannot be initiated w/NaN, so we first
+            # make them zero, then change them to NaN
+            not_finite = ~np.isfinite(ma)
+            ma[not_finite] = 0
+            tm = Time(ma, format='jd')
+            tm[not_finite] = np.nan
+            return tm
 
         raise ValueError('"which" kwarg must be "next", "previous" or '
                          '"nearest".')

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -924,7 +924,8 @@ class Observer(object):
                 return previous_event
 
         if which == 'nearest':
-            if previous_event.value.mask or next_event.value.mask:
+            if not (np.isfinite(previous_event.value) and
+                    np.isfinite(next_event.value)):
                 # always up?  Or some other case?
                 return next_event
             mask = abs(time - previous_event) < abs(time - next_event)

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -924,6 +924,9 @@ class Observer(object):
                 return previous_event
 
         if which == 'nearest':
+            if np.isnan(previous_event.value) or np.isnan(next_event.value):
+                # always up?  Or some other case?
+                return next_event
             mask = abs(time - previous_event) < abs(time - next_event)
             return Time(np.where(mask, previous_event.utc.jd,
                                  next_event.utc.jd), format='jd')

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -924,7 +924,7 @@ class Observer(object):
                 return previous_event
 
         if which == 'nearest':
-            if np.isnan(previous_event.value) or np.isnan(next_event.value):
+            if previous_event.value.mask or next_event.value.mask:
                 # always up?  Or some other case?
                 return next_event
             mask = abs(time - previous_event) < abs(time - next_event)

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -152,7 +152,8 @@ def test_rise_set_transit_nearest_vector():
     vega = SkyCoord(279.23473479*u.deg, 38.78368896*u.deg)
     mira = SkyCoord(34.83663376*u.deg, -2.97763767*u.deg)
     sirius = SkyCoord(101.28715533*u.deg, -16.71611586*u.deg)
-    sc_list = [vega, mira, sirius]
+    polaris = SkyCoord(37.95456067*u.degree, 89.26410897*u.degree)
+    sc_list = [vega, mira, sirius, polaris]
 
     location = EarthLocation(10*u.deg, 45*u.deg, 0*u.m)
     time = Time('1995-06-21 00:00:00')
@@ -162,28 +163,34 @@ def test_rise_set_transit_nearest_vector():
     vega_rise = obs.target_rise_time(time, vega)
     mira_rise = obs.target_rise_time(time, mira)
     sirius_rise = obs.target_rise_time(time, sirius)
+    polaris_rise = obs.target_rise_time(time, polaris)
 
     assert rise_vector[0] == vega_rise
     assert rise_vector[1] == mira_rise
     assert rise_vector[2] == sirius_rise
+    assert rise_vector[3].value.mask and polaris_rise.value.mask
 
     set_vector = obs.target_set_time(time, sc_list)
     vega_set = obs.target_set_time(time, vega)
     mira_set = obs.target_set_time(time, mira)
     sirius_set = obs.target_set_time(time, sirius)
+    polaris_set = obs.target_set_time(time, polaris)
 
     assert set_vector[0] == vega_set
     assert set_vector[1] == mira_set
     assert set_vector[2] == sirius_set
+    assert set_vector[3].value.mask and polaris_set.value.mask
 
     transit_vector = obs.target_meridian_transit_time(time, sc_list)
     vega_trans = obs.target_meridian_transit_time(time, vega)
     mira_trans = obs.target_meridian_transit_time(time, mira)
     sirius_trans = obs.target_meridian_transit_time(time, sirius)
+    polaris_trans = obs.target_meridian_transit_time(time, polaris)
 
     assert transit_vector[0] == vega_trans
     assert transit_vector[1] == mira_trans
     assert transit_vector[2] == sirius_trans
+    assert transit_vector[3] == polaris_trans
 
 
 def print_pyephem_altaz(latitude, longitude, elevation, time, pressure,

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -1003,6 +1003,13 @@ def test_TargetAlwaysUpWarning(recwarn):
     assert issubclass(w.category, TargetAlwaysUpWarning)
     assert no_time.mask
 
+    # Regression test: make sure 'nearest' also works
+    no_time = obs.target_rise_time(time, polaris, which='nearest')
+
+    w = recwarn.pop(TargetAlwaysUpWarning)
+    assert issubclass(w.category, TargetAlwaysUpWarning)
+    assert no_time.mask
+
 
 def test_TargetNeverUpWarning(recwarn):
     lat = '-90:00:00'

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -1013,7 +1013,11 @@ def test_TargetAlwaysUpWarning(recwarn):
     # Regression test: make sure 'nearest' also works
     no_time = obs.target_rise_time(time, polaris, which='nearest')
 
-    w = recwarn.pop(TargetAlwaysUpWarning)
+    # Cycle back through warnings until a TargetAlwaysUpWarning is hit
+    # (other warnings can also be raised here)
+    while not issubclass(w.category, TargetAlwaysUpWarning):
+        w = recwarn.pop(TargetAlwaysUpWarning)
+
     assert issubclass(w.category, TargetAlwaysUpWarning)
     assert no_time.mask
 

--- a/docs/faq/iers.rst
+++ b/docs/faq/iers.rst
@@ -78,7 +78,7 @@ astropy's IERS machinery:
     import numpy as np
     import astropy.units as u
     from astropy.time import Time
-    from astropy.extern.six.moves.urllib.error import HTTPError
+    from six.moves.urllib.error import HTTPError
 
     # Download and cache the IERS Bulletins A and B  using astropy's machinery
     # (reminder: astroplan has its own function for this: `download_IERS_A`)


### PR DESCRIPTION
This PR fixes an issue where using 'nearest' will result in a traceback when requesting rise/set times for an always-up source.