### PR TITLE
Timezone and shading

### DIFF
--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -924,13 +924,20 @@ class Observer(object):
                 return previous_event
 
         if which == 'nearest':
-            if not (np.isfinite(previous_event.value) and
-                    np.isfinite(next_event.value)):
-                # always up?  Or some other case?
+            # Use some hacks to handle the non-rising/non-setting cases
+            try:
+                mask = abs(time - previous_event) < abs(time - next_event)
+            except TypeError:
+                # encountered if time is scalar & nan
                 return next_event
-            mask = abs(time - previous_event) < abs(time - next_event)
-            return Time(np.where(mask, previous_event.utc.jd,
-                                 next_event.utc.jd), format='jd')
+            ma = np.where(mask, previous_event.utc.jd, next_event.utc.jd)
+            # HACK: Time objects cannot be initiated w/NaN, so we first
+            # make them zero, then change them to NaN
+            not_finite = ~np.isfinite(ma)
+            ma[not_finite] = 0
+            tm = Time(ma, format='jd')
+            tm[not_finite] = np.nan
+            return tm
 
         raise ValueError('"which" kwarg must be "next", "previous" or '
                          '"nearest".')

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -924,7 +924,8 @@ class Observer(object):
                 return previous_event
 
         if which == 'nearest':
-            if previous_event.value.mask or next_event.value.mask:
+            if not (np.isfinite(previous_event.value) and
+                    np.isfinite(next_event.value)):
                 # always up?  Or some other case?
                 return next_event
             mask = abs(time - previous_event) < abs(time - next_event)

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -924,6 +924,9 @@ class Observer(object):
                 return previous_event
 
         if which == 'nearest':
+            if np.isnan(previous_event.value) or np.isnan(next_event.value):
+                # always up?  Or some other case?
+                return next_event
             mask = abs(time - previous_event) < abs(time - next_event)
             return Time(np.where(mask, previous_event.utc.jd,
                                  next_event.utc.jd), format='jd')

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -924,7 +924,7 @@ class Observer(object):
                 return previous_event
 
         if which == 'nearest':
-            if np.isnan(previous_event.value) or np.isnan(next_event.value):
+            if previous_event.value.mask or next_event.value.mask:
                 # always up?  Or some other case?
                 return next_event
             mask = abs(time - previous_event) < abs(time - next_event)

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -201,14 +201,22 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
 
         # Calculate and order twilights and set plotting alpha for each
         twilights = [
-            (observer.sun_set_time(Time(start) + tzoffset, which='next').datetime, 0.0),
-            (observer.twilight_evening_civil(Time(start) + tzoffset, which='next').datetime, 0.1),
-            (observer.twilight_evening_nautical(Time(start) + tzoffset, which='next').datetime, 0.2),
-            (observer.twilight_evening_astronomical(Time(start) + tzoffset, which='next').datetime, 0.3),
-            (observer.twilight_morning_astronomical(Time(start) + tzoffset, which='next').datetime, 0.4),
-            (observer.twilight_morning_nautical(Time(start) + tzoffset, which='next').datetime, 0.3),
-            (observer.twilight_morning_civil(Time(start) + tzoffset, which='next').datetime, 0.2),
-            (observer.sun_rise_time(Time(start) + tzoffset, which='next').datetime, 0.1),
+            (observer.sun_set_time(Time(start) + tzoffset,
+                                   which='next').datetime, 0.0),
+            (observer.twilight_evening_civil(Time(start) + tzoffset,
+                                             which='next').datetime, 0.1),
+            (observer.twilight_evening_nautical(Time(start) + tzoffset,
+                                                which='next').datetime, 0.2),
+            (observer.twilight_evening_astronomical(Time(start) + tzoffset,
+                                                    which='next').datetime, 0.3),
+            (observer.twilight_morning_astronomical(Time(start) + tzoffset,
+                                                    which='next').datetime, 0.4),
+            (observer.twilight_morning_nautical(Time(start) + tzoffset,
+                                                which='next').datetime, 0.3),
+            (observer.twilight_morning_civil(Time(start) + tzoffset,
+                                             which='next').datetime, 0.2),
+            (observer.sun_rise_time(Time(start) + tzoffset,
+                                    which='next').datetime, 0.1),
         ]
 
         twilights.sort(key=operator.itemgetter(0))

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -50,7 +50,7 @@ def _has_twin(ax):
 def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
                  style_sheet=None, brightness_shading=False,
                  altitude_yaxis=False, min_airmass=1.0, min_region=None,
-                 max_airmass=3.0, max_region=None):
+                 max_airmass=3.0, max_region=None, use_local_tz=False):
     r"""
     Plots airmass as a function of time for a given target.
 
@@ -122,6 +122,10 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
         If set, defines an interval between ``max_airmass`` and ``max_region``
         that will be shaded. Default is `None`.
 
+    use_local_tz : bool
+        If the time is specified in a local timezone, the time will be plotted
+        in that timezone.
+
     Returns
     -------
     ax : `~matplotlib.axes.Axes`
@@ -151,6 +155,12 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
     style_kwargs.setdefault('linewidth', 1.5)
     style_kwargs.setdefault('fmt', '-')
 
+    if hasattr(time, 'utcoffset') and use_local_tz:
+        tzoffset = time.utcoffset()
+        tzname = time.tzname()
+    else:
+        tzoffset = 0
+        tzname = 'UTC'
     # Populate time window if needed.
     time = Time(time)
     if time.isscalar:
@@ -165,7 +175,7 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
 
     for target in targets:
         # Calculate airmass
-        airmass = observer.altaz(time, target).secz
+        airmass = observer.altaz(time + tzoffset, target).secz
         # Mask out nonsense airmasses
         masked_airmass = np.ma.array(airmass, mask=airmass < 1)
 
@@ -176,34 +186,38 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
             target_name = ''
 
         # Plot data
-        ax.plot_date(time.plot_date, masked_airmass, label=target_name, **style_kwargs)
+        ax.plot_date((time + tzoffset).plot_date, masked_airmass, label=target_name, **style_kwargs)
 
     # Format the time axis
-    ax.set_xlim([time[0].plot_date, time[-1].plot_date])
+    xlo, xhi = (time[0] + tzoffset), (time[-1] + tzoffset)
+    ax.set_xlim([xlo.plot_date, xhi.plot_date])
     date_formatter = dates.DateFormatter('%H:%M')
     ax.xaxis.set_major_formatter(date_formatter)
     plt.setp(ax.get_xticklabels(), rotation=30, ha='right')
 
     # Shade background during night time
     if brightness_shading:
-        start = time[0].datetime
+        start = (time[0] + tzoffset).datetime
 
         # Calculate and order twilights and set plotting alpha for each
         twilights = [
-            (observer.sun_set_time(Time(start), which='next').datetime, 0.0),
-            (observer.twilight_evening_civil(Time(start), which='next').datetime, 0.1),
-            (observer.twilight_evening_nautical(Time(start), which='next').datetime, 0.2),
-            (observer.twilight_evening_astronomical(Time(start), which='next').datetime, 0.3),
-            (observer.twilight_morning_astronomical(Time(start), which='next').datetime, 0.4),
-            (observer.twilight_morning_nautical(Time(start), which='next').datetime, 0.3),
-            (observer.twilight_morning_civil(Time(start), which='next').datetime, 0.2),
-            (observer.sun_rise_time(Time(start), which='next').datetime, 0.1),
+            (observer.sun_set_time(Time(start) + tzoffset, which='next').datetime, 0.0),
+            (observer.twilight_evening_civil(Time(start) + tzoffset, which='next').datetime, 0.1),
+            (observer.twilight_evening_nautical(Time(start) + tzoffset, which='next').datetime, 0.2),
+            (observer.twilight_evening_astronomical(Time(start) + tzoffset, which='next').datetime, 0.3),
+            (observer.twilight_morning_astronomical(Time(start) + tzoffset, which='next').datetime, 0.4),
+            (observer.twilight_morning_nautical(Time(start) + tzoffset, which='next').datetime, 0.3),
+            (observer.twilight_morning_civil(Time(start) + tzoffset, which='next').datetime, 0.2),
+            (observer.sun_rise_time(Time(start) + tzoffset, which='next').datetime, 0.1),
         ]
 
         twilights.sort(key=operator.itemgetter(0))
-        for i, twi in enumerate(twilights[1:], 1):
-            ax.axvspan(twilights[i - 1][0], twilights[i][0],
-                       ymin=0, ymax=1, color='grey', alpha=twi[1])
+        # add in left & right edges, so that if the airmass plot is requested
+        # during the day, night is properly shaded
+        for tw_left, tw_right in zip([(xlo.datetime, twilights[0][1])] + twilights,
+                                     twilights + [(xhi.datetime, twilights[0][1])]):
+            ax.axvspan(tw_left[0], tw_right[0],
+                       ymin=0, ymax=1, color='grey', alpha=tw_right[1])
 
     # Invert y-axis and set limits.
     y_lim = ax.get_ylim()
@@ -221,7 +235,10 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
 
     # Set labels.
     ax.set_ylabel("Airmass")
-    ax.set_xlabel("Time from {0} [UTC]".format(min(time).datetime.date()))
+    if use_local_tz:
+        ax.set_xlabel("Time from {0} [{1}]".format(min(time + tzoffset).datetime.date(), tzname))
+    else:
+        ax.set_xlabel("Time from {0} [{1}]".format(min(time).datetime.date(), tzname))
 
     if altitude_yaxis and not _has_twin(ax):
         altitude_ticks = np.array([90, 60, 50, 40, 30, 20])

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -152,7 +152,8 @@ def test_rise_set_transit_nearest_vector():
     vega = SkyCoord(279.23473479*u.deg, 38.78368896*u.deg)
     mira = SkyCoord(34.83663376*u.deg, -2.97763767*u.deg)
     sirius = SkyCoord(101.28715533*u.deg, -16.71611586*u.deg)
-    sc_list = [vega, mira, sirius]
+    polaris = SkyCoord(37.95456067*u.degree, 89.26410897*u.degree)
+    sc_list = [vega, mira, sirius, polaris]
 
     location = EarthLocation(10*u.deg, 45*u.deg, 0*u.m)
     time = Time('1995-06-21 00:00:00')
@@ -162,28 +163,34 @@ def test_rise_set_transit_nearest_vector():
     vega_rise = obs.target_rise_time(time, vega)
     mira_rise = obs.target_rise_time(time, mira)
     sirius_rise = obs.target_rise_time(time, sirius)
+    polaris_rise = obs.target_rise_time(time, polaris)
 
     assert rise_vector[0] == vega_rise
     assert rise_vector[1] == mira_rise
     assert rise_vector[2] == sirius_rise
+    assert rise_vector[3].value.mask and polaris_rise.value.mask
 
     set_vector = obs.target_set_time(time, sc_list)
     vega_set = obs.target_set_time(time, vega)
     mira_set = obs.target_set_time(time, mira)
     sirius_set = obs.target_set_time(time, sirius)
+    polaris_set = obs.target_set_time(time, polaris)
 
     assert set_vector[0] == vega_set
     assert set_vector[1] == mira_set
     assert set_vector[2] == sirius_set
+    assert set_vector[3].value.mask and polaris_set.value.mask
 
     transit_vector = obs.target_meridian_transit_time(time, sc_list)
     vega_trans = obs.target_meridian_transit_time(time, vega)
     mira_trans = obs.target_meridian_transit_time(time, mira)
     sirius_trans = obs.target_meridian_transit_time(time, sirius)
+    polaris_trans = obs.target_meridian_transit_time(time, polaris)
 
     assert transit_vector[0] == vega_trans
     assert transit_vector[1] == mira_trans
     assert transit_vector[2] == sirius_trans
+    assert transit_vector[3] == polaris_trans
 
 
 def print_pyephem_altaz(latitude, longitude, elevation, time, pressure,

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -1003,6 +1003,13 @@ def test_TargetAlwaysUpWarning(recwarn):
     assert issubclass(w.category, TargetAlwaysUpWarning)
     assert no_time.mask
 
+    # Regression test: make sure 'nearest' also works
+    no_time = obs.target_rise_time(time, polaris, which='nearest')
+
+    w = recwarn.pop(TargetAlwaysUpWarning)
+    assert issubclass(w.category, TargetAlwaysUpWarning)
+    assert no_time.mask
+
 
 def test_TargetNeverUpWarning(recwarn):
     lat = '-90:00:00'

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -1013,7 +1013,11 @@ def test_TargetAlwaysUpWarning(recwarn):
     # Regression test: make sure 'nearest' also works
     no_time = obs.target_rise_time(time, polaris, which='nearest')
 
-    w = recwarn.pop(TargetAlwaysUpWarning)
+    # Cycle back through warnings until a TargetAlwaysUpWarning is hit
+    # (other warnings can also be raised here)
+    while not issubclass(w.category, TargetAlwaysUpWarning):
+        w = recwarn.pop(TargetAlwaysUpWarning)
+
     assert issubclass(w.category, TargetAlwaysUpWarning)
     assert no_time.mask
 

--- a/docs/faq/iers.rst
+++ b/docs/faq/iers.rst
@@ -78,7 +78,7 @@ astropy's IERS machinery:
     import numpy as np
     import astropy.units as u
     from astropy.time import Time
-    from astropy.extern.six.moves.urllib.error import HTTPError
+    from six.moves.urllib.error import HTTPError
 
     # Download and cache the IERS Bulletins A and B  using astropy's machinery
     # (reminder: astroplan has its own function for this: `download_IERS_A`)


### PR DESCRIPTION
This PR adds support for timezone-specific airmass plots, and in the process corrects an error in which nighttime would be incorrectly unshaded if it is not centered in the plot.

Example:
![image](https://user-images.githubusercontent.com/143715/71448052-d8456380-2704-11ea-88aa-4a300e227522.png)
![image](https://user-images.githubusercontent.com/143715/71448053-db405400-2704-11ea-914e-b6d3395f91c1.png)

Calls look like this:
```
plot_airmass(pcyg_target, CTO, now.to_datetime(timezone=CTO.timezone), use_local_tz=True, brightness_shading=True)
```
`now` is an astropy time object, `CTO` is an observatory (UF Campus Teaching Observatory).

This PR is built on https://github.com/astropy/astroplan/pull/445 but does not depend on it; it can be refactored to be separate if needed.