### PR TITLE
fix timezone handling in plot_airmass

### DIFF
--- a/astroplan/plots/tests/test_sky.py
+++ b/astroplan/plots/tests/test_sky.py
@@ -27,7 +27,6 @@ def test_image_example():
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
 @pytest.mark.mpl_image_compare
 def test_timezone():
-    import matplotlib.pyplot as plt
     from astropy import coordinates
     from astropy import units as u
     from ..time_dependent import plot_airmass
@@ -35,8 +34,9 @@ def test_timezone():
     import datetime
     import pytz
 
-    bg = coordinates.SkyCoord.from_name('Betelgeuse')
-    vla = Observer(coordinates.EarthLocation.of_site('VLA'))
+    betelgeuse = coordinates.SkyCoord(88.79293899*u.deg, 7.407064*u.deg, frame='icrs')
+    observer = Observer(coordinates.EarthLocation.of_site('subaru'))
+    # Eastern time... because you're remote-operating Subaru from home...?
     now_ET = pytz.timezone('US/Eastern').localize(datetime.datetime.now())
 
-    plot_airmass(bg, vla, now_ET, use_local_tz=True)
+    plot_airmass(betelgeuse, observer, now_ET, use_local_tz=True)

--- a/astroplan/plots/tests/test_sky.py
+++ b/astroplan/plots/tests/test_sky.py
@@ -22,3 +22,21 @@ def test_image_example():
     ax = fig.add_subplot(1, 1, 1)
     ax.plot([1, 2, 3])
     return fig
+
+
+@pytest.mark.skipif('not HAS_MATPLOTLIB')
+@pytest.mark.mpl_image_compare
+def test_timezone():
+    import matplotlib.pyplot as plt
+    from astropy import coordinates
+    from astropy import units as u
+    from ..time_dependent import plot_airmass
+    from ... import Observer
+    import datetime
+    import pytz
+
+    bg = coordinates.SkyCoord.from_name('Betelgeuse')
+    vla = Observer(coordinates.EarthLocation.of_site('VLA'))
+    now_ET = pytz.timezone('US/Eastern').localize(datetime.datetime.now())
+
+    plot_airmass(bg, vla, now_ET, use_local_tz=True)

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -165,25 +165,22 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
         tzoffset = 0
         tzname = 'UTC'
         tzinfo = None
-    log.debug(f"Using time zone offset {tzoffset} for "
-              f"time zone {tzname}")
     # Populate time window if needed.
     # (plot against local time if that's requested)
     timetoplot = Time(time) + tzoffset
     if timetoplot.isscalar:
         timetoplot = timetoplot + np.linspace(-12, 12, 100)*u.hour
-        time_ut = timetoplot - tzoffset
     elif len(timetoplot) == 1:
         warnings.warn('You used a Time array of length 1.  You probably meant '
                       'to use a scalar. (Or maybe a list with length > 1?).',
                       PlotWarning)
+    time_ut = timetoplot - tzoffset
 
     if not isinstance(targets, Sequence):
         targets = [targets]
 
     for target in targets:
         # Calculate airmass
-        # (time will be correct UTC time)
         airmass = observer.altaz(time_ut, target).secz
         # Mask out nonsense airmasses
         masked_airmass = np.ma.array(airmass, mask=airmass < 1)
@@ -210,6 +207,7 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
 
         # Calculate and order twilights and set plotting alpha for each
         twilights = [
+            # TODO in next commit: Clean this up.
             (observer.sun_set_time(Time(start),
                                    which='next').datetime.replace(tzinfo=pytz.utc), 0.0),
             (observer.twilight_evening_civil(Time(start),
@@ -227,7 +225,6 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
             (observer.sun_rise_time(Time(start),
                                     which='next').datetime.replace(tzinfo=pytz.utc), 0.1),
         ]
-        log.debug(f"Twilights: {twilights}")
 
         twilights.sort(key=operator.itemgetter(0))
         # add in left & right edges, so that if the airmass plot is requested

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -167,14 +167,14 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
         tzinfo = None
     # Populate time window if needed.
     # (plot against local time if that's requested)
-    timetoplot = Time(time) + tzoffset
-    if timetoplot.isscalar:
-        timetoplot = timetoplot + np.linspace(-12, 12, 100)*u.hour
-    elif len(timetoplot) == 1:
+    time_ut = Time(time)
+    if time_ut.isscalar:
+        time_ut = time_ut + np.linspace(-12, 12, 100)*u.hour
+    elif len(time_ut) == 1:
         warnings.warn('You used a Time array of length 1.  You probably meant '
                       'to use a scalar. (Or maybe a list with length > 1?).',
                       PlotWarning)
-    time_ut = timetoplot - tzoffset
+    timetoplot = time_ut + tzoffset
 
     if not isinstance(targets, Sequence):
         targets = [targets]

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -6,8 +6,10 @@ import numpy as np
 import operator
 import astropy.units as u
 from astropy.time import Time
+from astropy import log
 from collections import Sequence
 import warnings
+import pytz
 
 from ..exceptions import PlotWarning
 from ..utils import _set_mpl_style_sheet
@@ -158,14 +160,20 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
     if hasattr(time, 'utcoffset') and use_local_tz:
         tzoffset = time.utcoffset()
         tzname = time.tzname()
+        tzinfo = time.tzinfo
     else:
         tzoffset = 0
         tzname = 'UTC'
+        tzinfo = None
+    log.debug(f"Using time zone offset {tzoffset} for "
+              f"time zone {tzname}")
     # Populate time window if needed.
-    time = Time(time)
-    if time.isscalar:
-        time = time + np.linspace(-12, 12, 100)*u.hour
-    elif len(time) == 1:
+    # (plot against local time if that's requested)
+    timetoplot = Time(time) + tzoffset
+    if timetoplot.isscalar:
+        timetoplot = timetoplot + np.linspace(-12, 12, 100)*u.hour
+        time_ut = timetoplot - tzoffset
+    elif len(timetoplot) == 1:
         warnings.warn('You used a Time array of length 1.  You probably meant '
                       'to use a scalar. (Or maybe a list with length > 1?).',
                       PlotWarning)
@@ -175,7 +183,8 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
 
     for target in targets:
         # Calculate airmass
-        airmass = observer.altaz(time + tzoffset, target).secz
+        # (time will be correct UTC time)
+        airmass = observer.altaz(time_ut, target).secz
         # Mask out nonsense airmasses
         masked_airmass = np.ma.array(airmass, mask=airmass < 1)
 
@@ -185,11 +194,11 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
         except AttributeError:
             target_name = ''
 
-        # Plot data
-        ax.plot_date((time + tzoffset).plot_date, masked_airmass, label=target_name, **style_kwargs)
+        # Plot data (against timezone-offset time)
+        ax.plot_date(timetoplot.plot_date, masked_airmass, label=target_name, **style_kwargs)
 
     # Format the time axis
-    xlo, xhi = (time[0] + tzoffset), (time[-1] + tzoffset)
+    xlo, xhi = (timetoplot[0]), (timetoplot[-1])
     ax.set_xlim([xlo.plot_date, xhi.plot_date])
     date_formatter = dates.DateFormatter('%H:%M')
     ax.xaxis.set_major_formatter(date_formatter)
@@ -197,34 +206,42 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
 
     # Shade background during night time
     if brightness_shading:
-        start = (time[0] + tzoffset).datetime
+        start = (time_ut[0]).datetime
 
         # Calculate and order twilights and set plotting alpha for each
         twilights = [
-            (observer.sun_set_time(Time(start) + tzoffset,
-                                   which='next').datetime, 0.0),
-            (observer.twilight_evening_civil(Time(start) + tzoffset,
-                                             which='next').datetime, 0.1),
-            (observer.twilight_evening_nautical(Time(start) + tzoffset,
-                                                which='next').datetime, 0.2),
-            (observer.twilight_evening_astronomical(Time(start) + tzoffset,
-                                                    which='next').datetime, 0.3),
-            (observer.twilight_morning_astronomical(Time(start) + tzoffset,
-                                                    which='next').datetime, 0.4),
-            (observer.twilight_morning_nautical(Time(start) + tzoffset,
-                                                which='next').datetime, 0.3),
-            (observer.twilight_morning_civil(Time(start) + tzoffset,
-                                             which='next').datetime, 0.2),
-            (observer.sun_rise_time(Time(start) + tzoffset,
-                                    which='next').datetime, 0.1),
+            (observer.sun_set_time(Time(start),
+                                   which='next').datetime.replace(tzinfo=pytz.utc), 0.0),
+            (observer.twilight_evening_civil(Time(start),
+                                             which='next').datetime.replace(tzinfo=pytz.utc), 0.1),
+            (observer.twilight_evening_nautical(Time(start),
+                                                which='next').datetime.replace(tzinfo=pytz.utc), 0.2),
+            (observer.twilight_evening_astronomical(Time(start),
+                                                    which='next').datetime.replace(tzinfo=pytz.utc), 0.3),
+            (observer.twilight_morning_astronomical(Time(start),
+                                                    which='next').datetime.replace(tzinfo=pytz.utc), 0.4),
+            (observer.twilight_morning_nautical(Time(start),
+                                                which='next').datetime.replace(tzinfo=pytz.utc), 0.3),
+            (observer.twilight_morning_civil(Time(start),
+                                             which='next').datetime.replace(tzinfo=pytz.utc), 0.2),
+            (observer.sun_rise_time(Time(start),
+                                    which='next').datetime.replace(tzinfo=pytz.utc), 0.1),
         ]
+        log.debug(f"Twilights: {twilights}")
 
         twilights.sort(key=operator.itemgetter(0))
         # add in left & right edges, so that if the airmass plot is requested
         # during the day, night is properly shaded
-        for tw_left, tw_right in zip([(xlo.datetime, twilights[0][1])] + twilights,
-                                     twilights + [(xhi.datetime, twilights[0][1])]):
-            ax.axvspan(tw_left[0], tw_right[0],
+        for tw_left, tw_right in zip([(xlo.datetime.replace(tzinfo=tzinfo), twilights[0][1])] + twilights,
+                                     twilights + [(xhi.datetime.replace(tzinfo=tzinfo), twilights[0][1])]):
+            left = tw_left[0]
+            right = tw_right[0]
+            if tzinfo is not None:
+                # convert to local time zone (which is plotted), then hack away the tzinfo
+                # so that matplotlib doesn't try to double down on the conversion
+                left = left.astimezone(tzinfo).replace(tzinfo=None)
+                right = right.astimezone(tzinfo).replace(tzinfo=None)
+            ax.axvspan(left, right,
                        ymin=0, ymax=1, color='grey', alpha=tw_right[1])
 
     # Invert y-axis and set limits.
@@ -243,10 +260,7 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
 
     # Set labels.
     ax.set_ylabel("Airmass")
-    if use_local_tz:
-        ax.set_xlabel("Time from {0} [{1}]".format(min(time + tzoffset).datetime.date(), tzname))
-    else:
-        ax.set_xlabel("Time from {0} [{1}]".format(min(time).datetime.date(), tzname))
+    ax.set_xlabel("Time from {0} [{1}]".format(min(timetoplot).datetime.date(), tzname))
 
     if altitude_yaxis and not _has_twin(ax):
         altitude_ticks = np.array([90, 60, 50, 40, 30, 20])

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -207,30 +207,28 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
 
         # Calculate and order twilights and set plotting alpha for each
         twilights = [
-            # TODO in next commit: Clean this up.
-            (observer.sun_set_time(Time(start),
-                                   which='next').datetime.replace(tzinfo=pytz.utc), 0.0),
-            (observer.twilight_evening_civil(Time(start),
-                                             which='next').datetime.replace(tzinfo=pytz.utc), 0.1),
-            (observer.twilight_evening_nautical(Time(start),
-                                                which='next').datetime.replace(tzinfo=pytz.utc), 0.2),
-            (observer.twilight_evening_astronomical(Time(start),
-                                                    which='next').datetime.replace(tzinfo=pytz.utc), 0.3),
-            (observer.twilight_morning_astronomical(Time(start),
-                                                    which='next').datetime.replace(tzinfo=pytz.utc), 0.4),
-            (observer.twilight_morning_nautical(Time(start),
-                                                which='next').datetime.replace(tzinfo=pytz.utc), 0.3),
-            (observer.twilight_morning_civil(Time(start),
-                                             which='next').datetime.replace(tzinfo=pytz.utc), 0.2),
-            (observer.sun_rise_time(Time(start),
-                                    which='next').datetime.replace(tzinfo=pytz.utc), 0.1),
+            (observer.sun_set_time(Time(start), which='next'), 0.0),
+            (observer.twilight_evening_civil(Time(start), which='next'), 0.1),
+            (observer.twilight_evening_nautical(Time(start), which='next'), 0.2),
+            (observer.twilight_evening_astronomical(Time(start), which='next'), 0.3),
+            (observer.twilight_morning_astronomical(Time(start), which='next'), 0.4),
+            (observer.twilight_morning_nautical(Time(start), which='next'), 0.3),
+            (observer.twilight_morning_civil(Time(start), which='next'), 0.2),
+            (observer.sun_rise_time(Time(start), which='next'), 0.1),
         ]
 
+        # add 'UTC' to each datetime object created above
+        twilights = [(t[0].datetime.replace(tzinfo=pytz.utc), t[1])
+                     for t in twilights]
+
         twilights.sort(key=operator.itemgetter(0))
+
         # add in left & right edges, so that if the airmass plot is requested
         # during the day, night is properly shaded
-        for tw_left, tw_right in zip([(xlo.datetime.replace(tzinfo=tzinfo), twilights[0][1])] + twilights,
-                                     twilights + [(xhi.datetime.replace(tzinfo=tzinfo), twilights[0][1])]):
+        left_edges = [(xlo.datetime.replace(tzinfo=tzinfo), twilights[0][1])] + twilights
+        right_edges = twilights + [(xhi.datetime.replace(tzinfo=tzinfo), twilights[0][1])]
+
+        for tw_left, tw_right in zip(left_edges, right_edges):
             left = tw_left[0]
             right = tw_right[0]
             if tzinfo is not None:

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -203,18 +203,18 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
 
     # Shade background during night time
     if brightness_shading:
-        start = (time_ut[0]).datetime
+        start = time_ut[0]
 
         # Calculate and order twilights and set plotting alpha for each
         twilights = [
-            (observer.sun_set_time(Time(start), which='next'), 0.0),
-            (observer.twilight_evening_civil(Time(start), which='next'), 0.1),
-            (observer.twilight_evening_nautical(Time(start), which='next'), 0.2),
-            (observer.twilight_evening_astronomical(Time(start), which='next'), 0.3),
-            (observer.twilight_morning_astronomical(Time(start), which='next'), 0.4),
-            (observer.twilight_morning_nautical(Time(start), which='next'), 0.3),
-            (observer.twilight_morning_civil(Time(start), which='next'), 0.2),
-            (observer.sun_rise_time(Time(start), which='next'), 0.1),
+            (observer.sun_set_time(start, which='next'), 0.0),
+            (observer.twilight_evening_civil(start, which='next'), 0.1),
+            (observer.twilight_evening_nautical(start, which='next'), 0.2),
+            (observer.twilight_evening_astronomical(start, which='next'), 0.3),
+            (observer.twilight_morning_astronomical(start, which='next'), 0.4),
+            (observer.twilight_morning_nautical(start, which='next'), 0.3),
+            (observer.twilight_morning_civil(start, which='next'), 0.2),
+            (observer.sun_rise_time(start, which='next'), 0.1),
         ]
 
         # add 'UTC' to each datetime object created above

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -6,7 +6,6 @@ import numpy as np
 import operator
 import astropy.units as u
 from astropy.time import Time
-from astropy import log
 from collections import Sequence
 import warnings
 import pytz


### PR DESCRIPTION
In Issue #452, I reported that the local timezone setting in the airmass plots wasn't working.  This PR fixes it.

I attempted to add a test, but the test doesn't really test anything at the moment, it's more of a placeholder / something you can check to make sure it looks right.  The real test is this:

```

from astropy import coordinates
from astropy import units as u
from astroplan.plots.time_dependent import plot_airmass
from astroplan import Observer
import datetime
import pytz
from astropy import log
from astropy.time import Time
log.setLevel('DEBUG')

bg = coordinates.SkyCoord.from_name('Betelgeuse')
CTO = Observer(location=coordinates.EarthLocation(lat=29.643018, lon=-82.349004*u.deg, height=31*u.m),
               timezone='EST',
               name='University of Florida Campus Teaching Observatory',
              )
now_ET = pytz.timezone('US/Eastern').localize(datetime.datetime.now())

print(f"now: {datetime.datetime.now()}, {Time(datetime.datetime.now())}")
print(f"now_ET: {now_ET}, {Time(now_ET)}")


import pylab as pl
pl.figure(2).clf()
plot_airmass(bg, CTO, now_ET, use_local_tz=False, brightness_shading=True)

print()
pl.figure(1).clf()
plot_airmass(bg, CTO, now_ET, use_local_tz=True, brightness_shading=True)
```
![test1_est](https://user-images.githubusercontent.com/143715/72932942-c0c2c000-3d2e-11ea-88c0-8247d0b98c02.png)
![test1_utc](https://user-images.githubusercontent.com/143715/72932944-c0c2c000-3d2e-11ea-8326-cb5bbaa20cb4.png)
