### PR TITLE
added `time_range` to `months_observable`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,9 @@
 0.9 (unreleased)
 ----------------
 
-No changes yet.
+- Fix time range in ``months_observable`` to not be only in 2014. Function now
+  accepts argument ``time_range`` and defaults to the current year. [#458]
+
 
 0.8 (2021-01-26)
 ----------------

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -10,6 +10,7 @@ from __future__ import (absolute_import, division, print_function,
 # Standard library
 from abc import ABCMeta, abstractmethod
 import datetime
+import time
 import warnings
 
 # Third-party
@@ -34,6 +35,12 @@ __all__ = ["AltitudeConstraint", "AirmassConstraint", "AtNightConstraint",
            "SecondaryEclipseConstraint", "Constraint", "TimeConstraint",
            "observability_table", "months_observable", "max_best_rescale",
            "min_best_rescale", "PhaseConstraint", "is_event_observable"]
+
+_current_year = time.localtime().tm_year  # needed for backward compatibility
+_current_year_time_range = Time(  # needed for backward compatibility
+    [str(_current_year) + '-01-01',
+     str(_current_year) + '-12-31']
+)
 
 
 def _make_cache_key(times, targets):
@@ -1086,10 +1093,11 @@ def is_event_observable(constraints, observer, target, times=None,
 
 
 def months_observable(constraints, observer, targets,
+                      time_range=_current_year_time_range,
                       time_grid_resolution=0.5*u.hour):
     """
     Determines which month the specified ``targets`` are observable for a
-    specific ``observer``, given the supplied ``constriants``.
+    specific ``observer``, given the supplied ``constraints``.
 
     Parameters
     ----------
@@ -1101,6 +1109,10 @@ def months_observable(constraints, observer, targets,
 
     targets : {list, `~astropy.coordinates.SkyCoord`, `~astroplan.FixedTarget`}
         Target or list of targets
+
+    time_range : `~astropy.time.Time` (optional)
+        Lower and upper bounds on time sequence
+        If `time_range` is not specified, defaults to current year (localtime)
 
     time_grid_resolution : `~astropy.units.Quantity` (optional)
         If ``time_range`` is specified, determine whether constraints are met
@@ -1121,9 +1133,6 @@ def months_observable(constraints, observer, targets,
     if not hasattr(constraints, '__len__'):
         constraints = [constraints]
 
-    # Calculate throughout the year of 2014 so as not to require forward
-    # extrapolation off of the IERS tables
-    time_range = Time(['2014-01-01', '2014-12-31'])
     times = time_grid_from_range(time_range, time_grid_resolution)
 
     # TODO: This method could be sped up a lot by dropping to the trigonometric

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -376,7 +376,8 @@ def test_months_observable():
     targets = [FixedTarget(coord=coord) for coord in coords]
     constraints = [AltitudeConstraint(min=80*u.deg),
                    AtNightConstraint.twilight_astronomical()]
-    months = months_observable(constraints, obs, targets)
+    time_range = Time(['2014-01-01', '2014-12-31'])
+    months = months_observable(constraints, obs, targets, time_range)
 
     should_be = [set({7, 8, 9, 10, 11, 12}), set({1, 2, 3, 10, 11, 12}),
                  set({1, 2, 3, 4, 5, 6}), set({4, 5, 6, 7, 8, 9})]

--- a/docs/tutorials/constraints.rst
+++ b/docs/tutorials/constraints.rst
@@ -101,7 +101,7 @@ This list of constraints can now be applied to our target list to determine:
     always_observable = is_always_observable(constraints, subaru, targets, time_range=time_range)
 
     # During what months are the targets ever observable?
-    best_months = months_observable(constraints, subaru, targets)
+    best_months = months_observable(constraints, subaru, targets, time_range)
 
 The `~astroplan.is_observable` and `~astroplan.is_always_observable` functions
 will return boolean arrays which tell you whether or not each target is


### PR DESCRIPTION
The `time_range` appears to be fixed to 2014 in `months_observable`.

As a test I ran the code inside `months_observable`, changing the time_range to January through December 1990 and, unsurprisingly, the observable months are different. Currently, the function only applies to 2014. This optional argument is added and set with a default range of the current year, dynamically set at import. The argument is made optional for backward compatibility in function signature and the default dynamically set to a sensible intended time range.

A different output, as a Quantity array or as a Time array with the year information encoded might be more useful, but this pull request is currently a bug fix only.

Signed-off-by: Nathaniel Starkman <nstarkman@protonmail.com>