### PR TITLE
Automatically use backup IERS URL if first one fails to download

### DIFF
--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -134,13 +134,8 @@ def download_IERS_A(show_progress=True):
         for url in urls:
             clear_download_cache(url)
 
-    for i, url in enumerate(urls):
-        try:
-            local_iers_a_path = download_file(url, cache=True,
-                                              show_progress=show_progress)
-        except urllib.error.URLError:
-            if i == len(urls) - 1:
-                raise
+    local_iers_a_path = download_file(urls[0], sources=urls, cache=True,
+                                      show_progress=show_progress)
 
     # Undo monkey patch set up by get_IERS_A_or_workaround
     iers.IERS.iers_table = iers.IERS_A.open(local_iers_a_path)


### PR DESCRIPTION
When looking into what could be causing #476 I saw that the `timeout` error was not being caught within `astroplan.utils.download_IERS_A()`. This results in the function failing if the primary URL times out, without trying the backup.

One solution might be to catch `timeout` in addition to `urllib.error.URLError`, but when looking at the equivilent function in [`astropy.utils.iers.IERS_Auto()`](https://github.com/astropy/astropy/blob/625c6e6257af40e4b5c1070c9b3f707e7b0953dd/astropy/utils/iers/iers.py#L670-L680) it seems you can just pass a list of source URLs to `astropy.utils.data.download_file()`, which will run through the list if the first one fails.

So this PR makes that minor change to mean `download_IERS_A()` mirrors the code in `IERS_Auto()`. Letting `download_file()` catch the errors also means that there's no longer any reason the enumerate through the list of URLs here, making things simpler here too.