### PR TITLE
Astropy compatibility - download caching fixes

### DIFF
--- a/astroplan/__init__.py
+++ b/astroplan/__init__.py
@@ -29,4 +29,4 @@ if not _ASTROPY_SETUP_:
     from .scheduling import *
     from .periodic import *
 
-    get_IERS_A_or_workaround()
+    download_IERS_A()

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -160,6 +160,7 @@ def test_galactic_plane_separation():
                                          twenty_deg_away], times=time)
     assert np.all(is_constraint_met == [False, True, True])
 
+
 # in astropy before v1.0.4, a recursion error is triggered by this test
 @pytest.mark.skipif('APY_LT104')
 def test_sun_separation():

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -69,7 +69,7 @@ def test_Observer_altaz():
     # Calculate altitude/azimuth with astroplan
     location = EarthLocation.from_geodetic(longitude, latitude, elevation)
     astroplan_obs = Observer(name='Observatory', location=location,
-                             pressure=pressure*u.bar)
+                             pressure=pressure)
     astroplan_vega = FixedTarget(vega_coords)
     altaz = astroplan_obs.altaz(time, astroplan_vega)
     astroplan_altitude = altaz.alt

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -37,7 +37,7 @@ def _low_precision_utc_to_ut1(self, jd1, jd2):
     This method mimics `~astropy.coordinates.builtin_frames.utils.get_dut1utc`
     """
     try:
-        if self.mjd * u.day not in IERS_Auto.open()['MJD']:
+        if self.mjd*u.day not in IERS_Auto.open()['MJD']:
             warnings.warn(IERS_A_WARNING, OldEarthOrientationDataWarning)
         return self.delta_ut1_utc
 
@@ -76,7 +76,7 @@ def download_IERS_A(show_progress=True):
 
 
 @u.quantity_input(time_resolution=u.hour)
-def time_grid_from_range(time_range, time_resolution=0.5 * u.hour):
+def time_grid_from_range(time_range, time_resolution=0.5*u.hour):
     """
     Get linearly-spaced sequence of times.
 
@@ -195,37 +195,37 @@ class EarthLocation_mock(EarthLocation):
 
     @classmethod
     def of_site_mock(cls, string):
-        subaru = EarthLocation.from_geodetic(-155.4761111111111 * u.deg,
-                                             19.825555555555564 * u.deg,
-                                             4139 * u.m)
+        subaru = EarthLocation.from_geodetic(-155.4761111111111*u.deg,
+                                             19.825555555555564*u.deg,
+                                             4139*u.m)
 
-        lco = EarthLocation.from_geodetic(-70.70166666666665 * u.deg,
-                                          -29.003333333333327 * u.deg,
-                                          2282 * u.m)
+        lco = EarthLocation.from_geodetic(-70.70166666666665*u.deg,
+                                          -29.003333333333327*u.deg,
+                                          2282*u.m)
 
-        aao = EarthLocation.from_geodetic(149.06608611111113 * u.deg,
-                                          -31.277038888888896 * u.deg,
-                                          1164 * u.m)
+        aao = EarthLocation.from_geodetic(149.06608611111113*u.deg,
+                                          -31.277038888888896*u.deg,
+                                          1164*u.m)
 
-        vbo = EarthLocation.from_geodetic(78.8266 * u.deg,
-                                          12.576659999999999 * u.deg,
-                                          725 * u.m)
+        vbo = EarthLocation.from_geodetic(78.8266*u.deg,
+                                          12.576659999999999*u.deg,
+                                          725*u.m)
 
-        apo = EarthLocation.from_geodetic(-105.82 * u.deg,
-                                          32.78 * u.deg,
-                                          2798 * u.m)
+        apo = EarthLocation.from_geodetic(-105.82*u.deg,
+                                          32.78*u.deg,
+                                          2798*u.m)
 
-        keck = EarthLocation.from_geodetic(-155.47833333333332 * u.deg,
-                                           19.828333333333326 * u.deg,
-                                           4160 * u.m)
+        keck = EarthLocation.from_geodetic(-155.47833333333332*u.deg,
+                                           19.828333333333326*u.deg,
+                                           4160*u.m)
 
-        kpno = EarthLocation.from_geodetic(-111.6 * u.deg,
-                                           31.963333333333342 * u.deg,
-                                           2120 * u.m)
+        kpno = EarthLocation.from_geodetic(-111.6*u.deg,
+                                           31.963333333333342*u.deg,
+                                           2120*u.m)
 
-        lapalma = EarthLocation.from_geodetic(-17.879999 * u.deg,
-                                              28.758333 * u.deg,
-                                              2327 * u.m)
+        lapalma = EarthLocation.from_geodetic(-17.879999*u.deg,
+                                              28.758333*u.deg,
+                                              2327*u.m)
 
         observatories = dict(lco=lco, subaru=subaru, aao=aao, vbo=vbo, apo=apo,
                              keck=keck, kpno=kpno, lapalma=lapalma)

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -25,6 +25,8 @@ IERS_A_WARNING = ("For best precision (on the order of arcseconds), you must "
                   ">>> from astroplan import download_IERS_A\n"
                   ">>> download_IERS_A()\n")
 
+# IF IERS table is unavailable we override the time deltas but need a way to
+# restore them next time table is available.
 BACKUP_Time_get_delta_ut1_utc = Time._get_delta_ut1_utc
 
 
@@ -65,8 +67,8 @@ def download_IERS_A(show_progress=True):
     try:
         iers_table = IERS_Auto()
         # Undo monkey patch set up by exception below.
-        IERS.iers_table = IERS_A.open(iers_table)
-        Time._get_delta_ut1_utc = BACKUP_Time_get_delta_ut1_utc
+        if Time._get_delta_ut1_utc != BACKUP_Time_get_delta_ut1_utc:
+            Time._get_delta_ut1_utc = BACKUP_Time_get_delta_ut1_utc
         return
     except Exception as err:
         Time._get_delta_ut1_utc = _low_precision_utc_to_ut1

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -51,8 +51,8 @@ def download_IERS_A(show_progress=True):
     Download and cache the IERS Bulletin A table.
 
     If one is already cached, download a new one and overwrite the old. Store
-    table in the astropy cache, and undo the monkey patching done by
-    `~astroplan.get_IERS_A_or_workaround`.
+    table in the astropy cache, and undo the monkey patching caused by earlier
+    failure (if applicable).
 
     If one does not exist, monkey patch `~astropy.time.Time._get_delta_ut1_utc`
     so that `~astropy.time.Time` objects don't raise errors by computing UT1-UTC

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -70,7 +70,7 @@ def download_IERS_A(show_progress=True):
         if Time._get_delta_ut1_utc != BACKUP_Time_get_delta_ut1_utc:
             Time._get_delta_ut1_utc = BACKUP_Time_get_delta_ut1_utc
         return
-    except Exception as err:
+    except Exception:
         warnings.warn(IERS_A_WARNING, OldEarthOrientationDataWarning)
         Time._get_delta_ut1_utc = _low_precision_utc_to_ut1
 

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -7,7 +7,7 @@ import warnings
 
 # Third-party
 import numpy as np
-from astropy.utils.iers import IERS, IERS_Auto, IERS_A
+from astropy.utils.iers import IERS_Auto
 from astropy.time import Time
 import astropy.units as u
 from astropy.coordinates import EarthLocation
@@ -65,12 +65,13 @@ def download_IERS_A(show_progress=True):
     """
     # Let astropy handle all the details.
     try:
-        iers_table = IERS_Auto()
+        IERS_Auto()
         # Undo monkey patch set up by exception below.
         if Time._get_delta_ut1_utc != BACKUP_Time_get_delta_ut1_utc:
             Time._get_delta_ut1_utc = BACKUP_Time_get_delta_ut1_utc
         return
     except Exception as err:
+        warnings.warn(IERS_A_WARNING, OldEarthOrientationDataWarning)
         Time._get_delta_ut1_utc = _low_precision_utc_to_ut1
 
 

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -3,12 +3,10 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 # Standard library
-import urllib.error
 import warnings
 
 # Third-party
 import numpy as np
-from astropy.utils.data import download_file, clear_download_cache
 from astropy.utils.iers import IERS, IERS_Auto, IERS_A
 from astropy.time import Time
 import astropy.units as u

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(name=PACKAGENAME,
       scripts=scripts,
       install_requires=['numpy>=1.10', 'astropy>=1.3', 'pytz', 'six'],
       extras_require=dict(
-          plotting=['matplotlib>=1.4'],
+          plotting=['matplotlib>=1.4,<3.3'],
           docs=['sphinx_rtd_theme'],
           test=['pytest-astropy'],
       ),


### PR DESCRIPTION
Removing older code that handled the IERS downloads in favor of the new mechanism used by `astropy`.

Specifically this is relying on `astropy` to do all the heavy lifting regarding IERS. Note that I'm not doing anything clever about earlier `astropy` versions so this might not be entirely backwards compatible.  @bmorris3 we probably need to define some minimum requirement and work from there.

I've left the monkey-patching on error in here but personally I think it's a bit of an odd solution.

I've also left it so that the download happens upon initial `import astroplan`, which I also have mixed feelings about.

I'm also sneaking in one small change to a test so that things can pass (removing an extra `u.bar`). ~~My editor also reformatted some arithmetic operators so they conform to PEP so I'm leaving that. Can remove if not appropriate here.~~ -> removed these pep changes in favor of #482 

Edit:

Closes #433 
Closes #448 
Closes #471 
Closes #476 
Closes #477 
Closes #479

Edit 2:

I've pinned `matplotlib<3.3` for this PR otherwise we get test failures (see #468).  This should be reversed/updated once the other PRs are merged (which can only happen after this PR is merged).