### PR TITLE
trigger tests on branch PRs

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -11,7 +11,7 @@ on:
   #  tags: # run CI if specific tags are pushed
   pull_request:
      branches: # only build on PRs against 'main' if you need to further limit when CI is run.
-      - main
+      - master
 
 jobs:
   # Github Actions supports ubuntu, windows, and macos virtual environments:


### PR DESCRIPTION
The main branch is called 'master', not 'main'.

@bmorris3 
#no-changelog-entry-needed

Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>