### PR TITLE
convert quantities before they might be strings in to_table

### DIFF
--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -278,8 +278,8 @@ class Schedule(object):
                 end_times.append(slot.end.iso)
                 durations.append(slot.duration.to(u.minute).value)
                 target_names.append(slot.block.target.name)
-                ra.append(slot.block.target.ra)
-                dec.append(slot.block.target.dec)
+                ra.append(u.Quantity(slot.block.target.ra))
+                dec.append(u.Quantity(slot.block.target.dec))
                 config.append(slot.block.configuration)
             elif show_transitions and slot.block:
                 start_times.append(slot.start.iso)
@@ -300,8 +300,7 @@ class Schedule(object):
                 ra.append('')
                 dec.append('')
                 config.append('')
-        return Table([target_names, start_times, end_times, durations,
-                      u.Quantity(ra), u.Quantity(dec), config],
+        return Table([target_names, start_times, end_times, durations, ra, dec, config],
                      names=('target', 'start time (UTC)', 'end time (UTC)',
                             'duration (minutes)', 'ra', 'dec', 'configuration'))
 


### PR DESCRIPTION
trying to `u.Quantity` with a string, for example, `u.Quantity([m42.ra, ''])`,
yields a `TypeError`:
```
    print(u.Quantity([m42.ra, '']))
  File "~/.local/lib/python3.8/site-packages/astropy/units/quantity.py", line 382, in __new__
    raise TypeError("The value must be a valid Python or "
TypeError: The value must be a valid Python or Numpy numeric type.
```

this is exactly what happens in `to_table()` with transitions or unused slots
shown, because of the append `append('')` in `scheduling.py`.

so instead, do the `u.Quantity` conversion earlier where we know the type is
(should be!) a Numpy numeric (or other appropriate type).

this is, in a way, a rewrite of #370: really just moves the change there up a few lines. i tested that it works by hand on a table with `TransitionBlock`; what would yield the aforementioned `TypeError` on `master` now produces a table that can be printed:
```
     target         start time (UTC)         end time (UTC)      duration (minutes)      ra         dec      configuration  
--------------- ----------------------- ----------------------- ------------------- ----------- ----------- ----------------
            M42 2021-02-14 01:30:00.000 2021-02-14 02:23:20.000  53.333333333333414 83.82208333 -5.39111111 {'filter': 'Ha'}
TransitionBlock 2021-02-14 02:23:20.000 2021-02-14 02:23:29.136 0.15226966667478692                                       []
             M1 2021-02-14 02:23:29.136 2021-02-14 03:43:29.136   80.00000000000003 83.63308333     22.0145 {'filter': 'Ha'}
TransitionBlock 2021-02-14 05:53:29.136 2021-02-14 05:53:59.688   0.509194929995882                                       []
            M51 2021-02-14 05:53:59.688 2021-02-14 07:13:59.688   80.00000000000003  202.469575 47.19525833               {}
```

i'm not sure how to run the tests here, or i'd go ahead and add a test that `to_table` should work with examples from the docs :D