### PR TITLE
Tweaking end of observing block in Priority Scheduler

### DIFF
--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -807,7 +807,7 @@ class PriorityScheduler(Scheduler):
 
     def attempt_insert_block(self, b, new_start_time, start_time_idx):
         # set duration to be exact multiple of time resolution
-        duration_indices = np.int(np.ceil(
+        duration_indices = np.int(np.floor(
             float(b.duration / self.time_resolution)))
         b.duration = duration_indices * self.time_resolution
 


### PR DESCRIPTION
Fixes #502

The priority scheduler currently requires that the inserted observing block has a duration which is an integer multiple of the time resolution, and it rounds _up_ to the nearest integer multiple observing block duration. This can lead to cases where the observing block "overflows" beyond the end of the slot by a margin similar to the time resolution. Rounding down seems to fix this.

I'd love to see if anyone can test this change on their priority schedulers before we merge this, any testers out there? Our testing of the schedulers is simple compared to some of the use cases out there, so knowing it works on someone's production code would be great!