### PR TITLE
Save location details to Observer instance to match the docs.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@
 - Fix time range in ``months_observable`` to not be only in 2014. Function now
   accepts argument ``time_range`` and defaults to the current year. [#458]
 
-- Fix ``Observer`` not having longtitude, lattitude, and elevation parameters
-  as class instances. They are now properties calculated from the ``location``.
+- Fix ``Observer`` not having longtitude, latitude, and elevation parameters
+  as class attributes. They are now properties calculated from the ``location``.
 
 0.8 (2021-01-26)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Fix time range in ``months_observable`` to not be only in 2014. Function now
   accepts argument ``time_range`` and defaults to the current year. [#458]
 
+- Fix ``Observer`` not having longtitude, lattitude, and elevation parameters
+  as class instances. They are now properties calculated from the ``location``.
 
 0.8 (2021-01-26)
 ----------------

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -1960,7 +1960,7 @@ class Observer(object):
         return start_time, end_time
 
     @property
-    def longtitude(self):
+    def longitude(self):
         """longitude : float, str, `~astropy.units.Quantity` (optional)
             The longitude of the observing location. Should be valid input for
             initializing a `~astropy.coordinates.Longitude` object.

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -199,6 +199,9 @@ class Observer(object):
                             'latitude and longitude in degrees as '
                             'accepted by astropy.coordinates.Latitude and '
                             'astropy.coordinates.Latitude.')
+            
+        # Save location info to match docs:
+        self.longtitude, self.latitude, self.elevation = self.location.to_geodetic()[:3]  
 
         # Accept various timezone inputs, default to UTC
         if isinstance(timezone, datetime.tzinfo):

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -199,9 +199,6 @@ class Observer(object):
                             'latitude and longitude in degrees as '
                             'accepted by astropy.coordinates.Latitude and '
                             'astropy.coordinates.Latitude.')
-            
-        # Save location info to match docs:
-        self.longtitude, self.latitude, self.elevation = self.location.to_geodetic()[:3]  
 
         # Accept various timezone inputs, default to UTC
         if isinstance(timezone, datetime.tzinfo):
@@ -1961,3 +1958,15 @@ class Observer(object):
         end_time = self.sun_rise_time(start_time, which='next', horizon=horizon)
 
         return start_time, end_time
+
+    @property
+    def longtitude(self):
+        return self.location.lon
+
+    @property
+    def latitude(self):
+        return self.location.lat
+
+    @property
+    def elevation(self):
+        return self.location.height

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -209,6 +209,27 @@ class Observer(object):
             raise TypeError('timezone keyword should be a string, or an '
                             'instance of datetime.tzinfo')
 
+    @property
+    def longitude(self):
+        """longitude : `~astropy.coordinates.angles.Longitude` 
+            The longitude of the observing location derived from the `location`.
+        """
+        return self.location.lon
+
+    @property
+    def latitude(self):
+        """latitude : `~astropy.coordinates.angles.Latitude`
+            The latitude of the observing location derived from the `location`.
+        """
+        return self.location.lat
+
+    @property
+    def elevation(self):
+        """ elevation : `~astropy.units.Quantity`, default = 0 meters
+            The elevation of the observing `location` with respect to sea level.
+        """
+        return self.location.height
+
     def __repr__(self):
         """
         String representation of the `~astroplan.Observer` object.
@@ -1958,27 +1979,3 @@ class Observer(object):
         end_time = self.sun_rise_time(start_time, which='next', horizon=horizon)
 
         return start_time, end_time
-
-    @property
-    def longitude(self):
-        """longitude : float, str, `~astropy.units.Quantity` (optional)
-            The longitude of the observing location. Should be valid input for
-            initializing a `~astropy.coordinates.Longitude` object.
-        """
-        return self.location.lon
-
-    @property
-    def latitude(self):
-        """latitude : float, str, `~astropy.units.Quantity` (optional)
-            The latitude of the observing location. Should be valid input for
-            initializing a `~astropy.coordinates.Latitude` object.
-        """
-        return self.location.lat
-
-    @property
-    def elevation(self):
-        """ elevation : `~astropy.units.Quantity` (optional), default = 0 meters
-            The elevation of the observing location, with respect to sea
-            level. Defaults to sea level.
-        """
-        return self.location.height

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -211,17 +211,17 @@ class Observer(object):
 
     @property
     def longitude(self):
-        """The longitude of the observing location, derived from the `location`."""
+        """The longitude of the observing location, derived from the location."""
         return self.location.lon
 
     @property
     def latitude(self):
-        """The latitude of the observing location, derived from the `location`."""
+        """The latitude of the observing location, derived from the location."""
         return self.location.lat
 
     @property
     def elevation(self):
-        """The elevation of the observing `location` with respect to sea level."""
+        """The elevation of the observing location with respect to sea level."""
         return self.location.height
 
     def __repr__(self):

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -1961,12 +1961,24 @@ class Observer(object):
 
     @property
     def longtitude(self):
+        """longitude : float, str, `~astropy.units.Quantity` (optional)
+            The longitude of the observing location. Should be valid input for
+            initializing a `~astropy.coordinates.Longitude` object.
+        """
         return self.location.lon
 
     @property
     def latitude(self):
+        """latitude : float, str, `~astropy.units.Quantity` (optional)
+            The latitude of the observing location. Should be valid input for
+            initializing a `~astropy.coordinates.Latitude` object.
+        """
         return self.location.lat
 
     @property
     def elevation(self):
+        """ elevation : `~astropy.units.Quantity` (optional), default = 0 meters
+            The elevation of the observing location, with respect to sea
+            level. Defaults to sea level.
+        """
         return self.location.height

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -211,23 +211,17 @@ class Observer(object):
 
     @property
     def longitude(self):
-        """longitude : `~astropy.coordinates.angles.Longitude` 
-            The longitude of the observing location derived from the `location`.
-        """
+        """The longitude of the observing location, derived from the `location`."""
         return self.location.lon
 
     @property
     def latitude(self):
-        """latitude : `~astropy.coordinates.angles.Latitude`
-            The latitude of the observing location derived from the `location`.
-        """
+        """The latitude of the observing location, derived from the `location`."""
         return self.location.lat
 
     @property
     def elevation(self):
-        """ elevation : `~astropy.units.Quantity`, default = 0 meters
-            The elevation of the observing `location` with respect to sea level.
-        """
+        """The elevation of the observing `location` with respect to sea level."""
         return self.location.height
 
     def __repr__(self):

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -1345,14 +1345,11 @@ def test_sun_set_vs_mmto_almanac(mmto_sunset):
 
     assert abs(mmto_sunset - astroplan_sunset) < 1 * u.min
 
-def test_observer_long_lat_el():
+
+def test_observer_lon_lat_el():
     """Test that astropy.EarthLocation conversion to longitude,
-    latitude, and elevation is working correctly in Observer,
-    and that Observer.location is of type EarthLocation.
+    latitude, and elevation works correctly.
     """
     obs = Observer.at_site('Subaru')
-    assert isinstance(obs.location, EarthLocation)
-    lon, lat, el = obs.location.to_geodetic()[:3]
-    assert obs.longitude == lon
-    assert obs.latitude == lat
-    assert obs.elevation == el
+    for attr in ['longitude', 'latitude', 'longitude']:
+        assert hasattr(obs, attr)

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -1351,5 +1351,5 @@ def test_observer_lon_lat_el():
     latitude, and elevation works correctly.
     """
     obs = Observer.at_site('Subaru')
-    for attr in ['longitude', 'latitude', 'longitude']:
+    for attr in ['longitude', 'latitude', 'elevation']:
         assert hasattr(obs, attr)

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -1346,7 +1346,7 @@ def test_sun_set_vs_mmto_almanac(mmto_sunset):
     assert abs(mmto_sunset - astroplan_sunset) < 1 * u.min
 
 def test_observer_long_lat_el():
-    """Test that astropy.EarthLocation conversion to longtitude,
+    """Test that astropy.EarthLocation conversion to longitude,
     latitude, and elevation is working correctly in Observer,
     and that Observer.location is of type EarthLocation.
     """

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -1346,6 +1346,9 @@ def test_sun_set_vs_mmto_almanac(mmto_sunset):
     assert abs(mmto_sunset - astroplan_sunset) < 1 * u.min
 
 def test_observer_long_lat_el():
+    """Test that astropy.EarthLocation conversion to longtitude,
+    lattitude, and elevation is working correctly in Observer.
+    """
     obs = Observer.at_site('Subaru')
     lon, lat, el = obs.location.to_geodetic()[:3]
     assert obs.longtitude == lon

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -1344,3 +1344,10 @@ def test_sun_set_vs_mmto_almanac(mmto_sunset):
                                         horizon=-0.8333*u.deg, which='next')
 
     assert abs(mmto_sunset - astroplan_sunset) < 1 * u.min
+
+def test_observer_long_lat_el():
+    obs = Observer.at_site('Subaru')
+    lon, lat, el = obs.location.to_geodetic()[:3]
+    assert obs.longtitude == lon
+    assert obs.lattitude == lat
+    assert obs.elevation == el

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -1347,12 +1347,12 @@ def test_sun_set_vs_mmto_almanac(mmto_sunset):
 
 def test_observer_long_lat_el():
     """Test that astropy.EarthLocation conversion to longtitude,
-    lattitude, and elevation is working correctly in Observer,
+    latitude, and elevation is working correctly in Observer,
     and that Observer.location is of type EarthLocation.
     """
     obs = Observer.at_site('Subaru')
     assert isinstance(obs.location, EarthLocation)
     lon, lat, el = obs.location.to_geodetic()[:3]
     assert obs.longitude == lon
-    assert obs.lattitude == lat
+    assert obs.latitude == lat
     assert obs.elevation == el

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -1347,10 +1347,12 @@ def test_sun_set_vs_mmto_almanac(mmto_sunset):
 
 def test_observer_long_lat_el():
     """Test that astropy.EarthLocation conversion to longtitude,
-    lattitude, and elevation is working correctly in Observer.
+    lattitude, and elevation is working correctly in Observer,
+    and that Observer.location is of type EarthLocation.
     """
     obs = Observer.at_site('Subaru')
+    assert isinstance(obs.location, EarthLocation)
     lon, lat, el = obs.location.to_geodetic()[:3]
-    assert obs.longtitude == lon
+    assert obs.longitude == lon
     assert obs.lattitude == lat
     assert obs.elevation == el


### PR DESCRIPTION
Saves longitude latitude and elevation info to `Observer` class as properties to match the docs. Adds tests, docstrings, and updates changelog.

Fixes #521 (I also noticed longitude and latitude were missing).

# Discussion

The Linked PR addresses by adding `longitude`, `latitude`, and `elevation` methods with `@property` decorator that are re-calculated from the current `self.location` which is of type `astropy.coordinates.EarthLocation`. So that updating the location also updates the parameters. Added a meaningful test that should fail if the underlying function from `astropy` changes significantly.