### PR TITLE
Update for numpy int deprecation.

### DIFF
--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -766,7 +766,7 @@ class PriorityScheduler(Scheduler):
             # Select the most optimal time
 
             # calculate the number of time slots needed for this exposure
-            _stride_by = np.int(np.ceil(float(b.duration / time_resolution)))
+            _stride_by = int(np.ceil(float(b.duration / time_resolution)))
 
             # Stride the score arrays by that number
             _strided_scores = stride_array(constraint_scores, _stride_by)
@@ -810,7 +810,7 @@ class PriorityScheduler(Scheduler):
 
     def attempt_insert_block(self, b, new_start_time, start_time_idx):
         # set duration to be exact multiple of time resolution
-        duration_indices = np.int(np.floor(
+        duration_indices = int(np.floor(
             float(b.duration / self.time_resolution)))
         b.duration = duration_indices * self.time_resolution
 
@@ -877,7 +877,7 @@ class PriorityScheduler(Scheduler):
         # tweak durations to exact multiple of time resolution
         for block in (tb_before, tb_after):
             if block is not None:
-                block.duration = self.time_resolution * np.int(
+                block.duration = self.time_resolution * int(
                     np.ceil(float(block.duration / self.time_resolution))
                 )
 
@@ -894,7 +894,7 @@ class PriorityScheduler(Scheduler):
             ob_offset = 2 if tb_before_already_exists else 1
             previous_ob = self.schedule.slots[slot_index - ob_offset]
             if tb_before:
-                transition_indices = np.int(tb_before.duration / self.time_resolution)
+                transition_indices = int(tb_before.duration / self.time_resolution)
             else:
                 transition_indices = 0
 
@@ -909,7 +909,7 @@ class PriorityScheduler(Scheduler):
             next_ob = self.schedule.slots[slot_index + slot_offset].block
             end_idx = start_time_idx + duration_indices
             if tb_after:
-                end_idx += np.int(tb_after.duration/self.time_resolution)
+                end_idx += int(tb_after.duration / self.time_resolution)
                 if end_idx >= next_ob.start_idx:
                     # cannot schedule
                     return False

--- a/astroplan/tests/test_scheduling.py
+++ b/astroplan/tests/test_scheduling.py
@@ -31,16 +31,16 @@ only_at_night = [AtNightConstraint()]
 
 def test_observing_block():
     block = ObservingBlock(rigel, 1*u.minute, 0, configuration={'filter': 'b'})
-    assert(block.configuration['filter'] == 'b')
-    assert(block.target == rigel)
+    assert block.configuration['filter'] == 'b'
+    assert block.target == rigel
     times_per_exposure = [1*u.minute, 4*u.minute, 15*u.minute, 5*u.minute]
     numbers_of_exposures = [100, 4, 3, 12]
     readout_time = 0.5*u.minute
     for index in range(len(times_per_exposure)):
         block = ObservingBlock.from_exposures(vega, 0, times_per_exposure[index],
                                               numbers_of_exposures[index], readout_time)
-        assert(block.duration == numbers_of_exposures[index] *
-               (times_per_exposure[index] + readout_time))
+        assert (block.duration == numbers_of_exposures[index] * 
+                (times_per_exposure[index] + readout_time))
 
 
 def test_slot():

--- a/astroplan/tests/test_scheduling.py
+++ b/astroplan/tests/test_scheduling.py
@@ -39,7 +39,7 @@ def test_observing_block():
     for index in range(len(times_per_exposure)):
         block = ObservingBlock.from_exposures(vega, 0, times_per_exposure[index],
                                               numbers_of_exposures[index], readout_time)
-        assert (block.duration == numbers_of_exposures[index] * 
+        assert (block.duration == numbers_of_exposures[index] *
                 (times_per_exposure[index] + readout_time))
 
 

--- a/docs/tutorials/periodic.rst
+++ b/docs/tutorials/periodic.rst
@@ -100,7 +100,7 @@ Transit times via astroquery
 
 The development version of `astroquery`_ allows users to query for properties of
 known exoplanets with three different services:
-`~astroquery.exoplanet_orbit_database`, `~astroquery.nasa_exoplanet_archive`,
+`~astroquery.ipac.nexsci.nasa_exoplanet_archive`, `~astroquery.exoplanet_orbit_database`,
 and `~astroquery.open_exoplanet_catalogue`. In the example below, we will query
 for the properties of the transiting exoplanet TRAPPIST-1 b with astroquery, and
 calculate the times of the next three transits with
@@ -111,8 +111,9 @@ calculate the times of the next three transits with
     >>> # NASA Exoplanet Archive for planet properties
     >>> import astropy.units as u
     >>> from astropy.time import Time
-    >>> from astroquery.nasa_exoplanet_archive import NasaExoplanetArchive
-    >>> planet_properties = NasaExoplanetArchive.query_planet('TRAPPIST-1 b', all_columns=True)
+    >>> from astroquery.ipac.nexsci.nasa_exoplanet_archive import NasaExoplanetArchive
+    >>> planet_properties = NasaExoplanetArchive.query_object('TRAPPIST-1 b', select='*', table='pscomppars')
+
 
     >>> # get relevant planet properties
     >>> epoch = Time(planet_properties['pl_tranmid'], format='jd')


### PR DESCRIPTION
* Replace all `np.int` instances with just `int`.

Reference: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

Mentioned by @thusser in the `astroplan` slack channel. Thanks!