### PR TITLE
Adding MissingConstraintWarning warning

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,25 +16,4 @@ prune build
 prune docs/_build
 prune docs/api
 
-# the next few stanzas are for astropy_helpers.  It's derived from the
-# astropy_helpers/MANIFEST.in, but requires additional includes for the actual
-# package directory and egg-info.
-
-include astropy_helpers/README.rst
-include astropy_helpers/CHANGES.rst
-include astropy_helpers/LICENSE.rst
-recursive-include astropy_helpers/licenses *
-
-include astropy_helpers/ez_setup.py
-include astropy_helpers/ah_bootstrap.py
-
-recursive-include astropy_helpers/astropy_helpers *.py *.pyx *.c *.h
-recursive-include astropy_helpers/astropy_helpers.egg-info *
-# include the sphinx stuff with "*" because there are css/html/rst/etc.
-recursive-include astropy_helpers/astropy_helpers/sphinx *
-
-prune astropy_helpers/build
-prune astropy_helpers/astropy_helpers/tests
-
-
 global-exclude *.pyc *.o

--- a/astroplan/exceptions.py
+++ b/astroplan/exceptions.py
@@ -6,7 +6,8 @@ from astropy.utils.exceptions import AstropyWarning
 
 __all__ = ["TargetAlwaysUpWarning", "TargetNeverUpWarning",
            "OldEarthOrientationDataWarning", "PlotWarning",
-           "PlotBelowHorizonWarning", "AstroplanWarning"]
+           "PlotBelowHorizonWarning", "AstroplanWarning",
+           "MissingConstraintWarning"]
 
 
 class AstroplanWarning(AstropyWarning):
@@ -35,4 +36,9 @@ class PlotWarning(AstroplanWarning):
 
 class PlotBelowHorizonWarning(PlotWarning):
     """Warning for when something is hidden on a plot because it's below the horizon"""
+    pass
+
+
+class MissingConstraintWarning(AstroplanWarning):
+    """Triggered when a constraint is expected but not supplied"""
     pass

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -48,6 +48,20 @@ sys.modules[__name__] = deprecation_wrap_module(sys.modules[__name__],
                                                 deprecated=['MAGIC_TIME'])
 
 
+def _process_nans_in_jds(jds):
+    """
+    Some functions calculate times for events that won't happen, yielding nans. This wrapper
+    manages vectors of (potentially) invalid JDs that must be passed to the astropy.time.Time
+    constructor. Returns a masked Time object.
+    """
+    if np.isscalar(jds):
+        jds = np.array([jds])
+    not_finite = ~np.isfinite(jds)
+    masked_jds = np.ma.masked_array(jds.to(u.day).value if hasattr(jds, 'unit') else jds.copy())
+    masked_jds[not_finite] = np.ma.masked
+    return masked_jds
+
+
 def _generate_24hr_grid(t0, start, end, n_grid_points, for_deriv=False):
     """
     Generate a nearly linearly spaced grid of time durations.
@@ -684,17 +698,9 @@ class Observer(object):
         slope = (alt_after-alt_before) / ((jd_after - jd_before) * u.d)
         crossing_jd = (jd_after * u.d - ((alt_after - horizon) / slope))
 
-        # TODO: edit after https://github.com/astropy/astropy/issues/9612 has
-        # been addressed.
-
         # Determine whether or not there are NaNs in the crossing_jd array which
         # represent computations where no horizon crossing was found:
-        nans = np.isnan(crossing_jd)
-        # If there are, set them equal to zero, rather than np.nan
-        crossing_jd[nans] = 0
-        times = Time(crossing_jd, format='jd')
-        # Create a Time object with masked out times where there were NaNs
-        times[nans] = np.ma.masked
+        times = Time(_process_nans_in_jds(crossing_jd), format='jd')
 
         return np.squeeze(times)
 
@@ -924,20 +930,13 @@ class Observer(object):
                 return previous_event
 
         if which == 'nearest':
-            # Use some hacks to handle the non-rising/non-setting cases
             try:
                 mask = abs(time - previous_event) < abs(time - next_event)
+                ma = np.where(mask, previous_event.utc.jd, next_event.utc.jd)
             except TypeError:
                 # encountered if time is scalar & nan
-                return next_event
-            ma = np.where(mask, previous_event.utc.jd, next_event.utc.jd)
-            # HACK: Time objects cannot be initiated w/NaN, so we first
-            # make them zero, then change them to NaN
-            not_finite = ~np.isfinite(ma)
-            ma[not_finite] = 0
-            tm = Time(ma, format='jd')
-            tm[not_finite] = np.nan
-            return tm
+                ma = next_event.utc.jd if not next_event.isscalar else [next_event.utc.jd]
+            return Time(_process_nans_in_jds(ma), format='jd', scale='utc')
 
         raise ValueError('"which" kwarg must be "next", "previous" or '
                          '"nearest".')

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -22,6 +22,8 @@ from ..constraints import (AltitudeConstraint, AirmassConstraint, AtNightConstra
                            PrimaryEclipseConstraint, SecondaryEclipseConstraint,
                            is_event_observable)
 from ..periodic import EclipsingSystem
+from ..exceptions import MissingConstraintWarning
+
 
 APY_LT104 = not minversion('astropy', '1.0.4')
 
@@ -383,6 +385,10 @@ def test_months_observable():
                  set({1, 2, 3, 4, 5, 6}), set({4, 5, 6, 7, 8, 9})]
 
     assert months == should_be
+
+    with pytest.warns(MissingConstraintWarning):
+        constraints = [AtNightConstraint.twilight_astronomical()]
+        months_observable(constraints, obs, targets, time_range)
 
 
 def test_rescale_minmax():

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -156,7 +156,7 @@ def test_rise_set_transit_nearest_vector():
     sc_list = [vega, mira, sirius, polaris]
 
     location = EarthLocation(10*u.deg, 45*u.deg, 0*u.m)
-    time = Time('1995-06-21 00:00:00')
+    time = Time('2022-06-21 00:00:00')
 
     obs = Observer(location=location)
     rise_vector = obs.target_rise_time(time, sc_list)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ all =
     astroquery
 test =
     pytest-astropy
+    pytest-mpl
 docs =
     sphinx-astropy
     sphinx-rtd-theme


### PR DESCRIPTION
This PR was originally meant to address #514 from @knservis, but it widened into a few overdue improvements.

New features:
– A `MissingConstraintWarning` is raised when the user runs `months_observable(constraints, ...)` without an `AltitudeConstraint` or an `AirmassConstraint` among the constraints.

Improvements
– better handling of `nan` times within astroplan
– old manifest contents for astropy helpers are removed
– a hidden method `_process_nans_in_jds` handles the masking of "bad" times uniformly across methods within the `Observer` class

Closes #514