### PR TITLE
Removed redundancy between 'fmt' and 'linestyle' when using plot_date

### DIFF
--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -152,7 +152,6 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
     if style_kwargs is None:
         style_kwargs = {}
     style_kwargs = dict(style_kwargs)
-    style_kwargs.setdefault('linestyle', '-')
     style_kwargs.setdefault('linewidth', 1.5)
     style_kwargs.setdefault('fmt', '-')
 


### PR DESCRIPTION
Dear Astropy Maintainers,

This PR intends to remove the redundancy and consequent Matplotlib UserWarning when using `plot_date`. In `plot_date`, `fmt` is set by default to `'o'`, so changing this to `fmt='-' ` makes `linestyle='-'` redundant and produces a UserWarning advising of this redundancy. Such a warning is unnecessary and can be avoided if the line  `style_kwargs.setdefault('linestyle', '-')` is removed, thus letting `fmt` to define the linestyle as desired.

With my best regards,

Jaime A. Alvarado-Montes