### PR TITLE
Enabled calculation of lunar and solar transit

### DIFF
--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -512,6 +512,11 @@ class Observer(object):
         >>> target_altaz = apo.altaz(time, target) # doctest: +SKIP
         """
         if target is not None:
+            if target is MoonFlag:
+                target = get_moon(times, location=self.location)
+            elif target is SunFlag:
+                target = get_sun(times)
+
             time, target = self._preprocess_inputs(time, target, grid_times_targets)
 
         altaz_frame = AltAz(location=self.location, obstime=time,
@@ -809,15 +814,8 @@ class Observer(object):
 
         times = _generate_24hr_grid(time, start, end, n_grid_points)
 
-        if target is MoonFlag:
-            altaz = self.altaz(times, get_moon(times, location=self.location),
-                               grid_times_targets=grid_times_targets)
-        elif target is SunFlag:
-            altaz = self.altaz(times, get_sun(times),
-                               grid_times_targets=grid_times_targets)
-        else:
-            altaz = self.altaz(times, target,
-                               grid_times_targets=grid_times_targets)
+        altaz = self.altaz(times, target,
+                           grid_times_targets=grid_times_targets)
 
         altitudes = altaz.alt
 
@@ -886,16 +884,8 @@ class Observer(object):
         else:
             rise_set = 'setting'
 
-        #copied from cls._calc_riseset
-        if target is MoonFlag:
-            altaz = self.altaz(times, get_moon(times, location=self.location),
-                               grid_times_targets=grid_times_targets)
-        elif target is SunFlag:
-            altaz = self.altaz(times, get_sun(times),
-                               grid_times_targets=grid_times_targets)
-        else:
-            altaz = self.altaz(times, target,
-                               grid_times_targets=grid_times_targets)
+        altaz = self.altaz(times, target,
+                           grid_times_targets=grid_times_targets)
         
         altitudes = altaz.alt
         if altitudes.ndim > 2:

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -513,9 +513,9 @@ class Observer(object):
         """
         if target is not None:
             if target is MoonFlag:
-                target = get_moon(times, location=self.location)
+                target = get_moon(time, location=self.location)
             elif target is SunFlag:
-                target = get_sun(times)
+                target = get_sun(time)
 
             time, target = self._preprocess_inputs(time, target, grid_times_targets)
 
@@ -867,15 +867,12 @@ class Observer(object):
         if not isinstance(time, Time):
             time = Time(time)
 
-
         if prev_next == 'next':
             times = _generate_24hr_grid(time, 0, 1, n_grid_points,
                                         for_deriv=True)
         else:
             times = _generate_24hr_grid(time, -1, 0, n_grid_points,
                                         for_deriv=True)
-
-        
 
         # The derivative of the altitude with respect to time is increasing
         # from negative to positive values at the anti-transit of the meridian
@@ -886,7 +883,7 @@ class Observer(object):
 
         altaz = self.altaz(times, target,
                            grid_times_targets=grid_times_targets)
-        
+
         altitudes = altaz.alt
         if altitudes.ndim > 2:
             # shape is (M, N, ...) where M is targets and N is grid

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -7,7 +7,6 @@ from six import string_types
 import sys
 import datetime
 import warnings
-
 # Third-party
 from astropy.coordinates import (EarthLocation, SkyCoord, AltAz, get_sun,
                                  get_moon, Angle, Longitude)
@@ -870,12 +869,15 @@ class Observer(object):
         if not isinstance(time, Time):
             time = Time(time)
 
+
         if prev_next == 'next':
             times = _generate_24hr_grid(time, 0, 1, n_grid_points,
                                         for_deriv=True)
         else:
             times = _generate_24hr_grid(time, -1, 0, n_grid_points,
                                         for_deriv=True)
+
+        
 
         # The derivative of the altitude with respect to time is increasing
         # from negative to positive values at the anti-transit of the meridian
@@ -884,7 +886,17 @@ class Observer(object):
         else:
             rise_set = 'setting'
 
-        altaz = self.altaz(times, target, grid_times_targets=grid_times_targets)
+        #copied from cls._calc_riseset
+        if target is MoonFlag:
+            altaz = self.altaz(times, get_moon(times, location=self.location),
+                               grid_times_targets=grid_times_targets)
+        elif target is SunFlag:
+            altaz = self.altaz(times, get_sun(times),
+                               grid_times_targets=grid_times_targets)
+        else:
+            altaz = self.altaz(times, target,
+                               grid_times_targets=grid_times_targets)
+        
         altitudes = altaz.alt
         if altitudes.ndim > 2:
             # shape is (M, N, ...) where M is targets and N is grid


### PR DESCRIPTION
copied code from Observer._calc_riseset into ._calc_transit to enable calculations of lunar and solar transit. 