### PR TITLE
Fix plot_sky

### DIFF
--- a/astroplan/plots/sky.py
+++ b/astroplan/plots/sky.py
@@ -117,7 +117,11 @@ def plot_sky(target, observer, time, ax=None, style_kwargs=None,
 
     # Set up axes & plot styles if needed.
     if ax is None:
-        ax = plt.gcf().add_subplot(projection='polar')
+        if isinstance(plt.gca(), plt.PolarAxes):
+            ax = plt.gca()
+        else:
+            ax = plt.axes(polar=True)
+
     if style_kwargs is None:
         style_kwargs = {}
     style_kwargs = dict(style_kwargs)


### PR DESCRIPTION
check if current axes is `plt.PolarAxes` before draw. 
Makes multiple targets can be plotted in one sky map.

May be a response to my issue #542 

Thanks for your time