### PR TITLE
PriorityScheduler: Update _get_filled_indices() to avoid 'block already occupied' ValueError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 
 - Minimum Python version is now 3.11. Also bumped minversion
   of dependencies. [#605]
+- Fix ``block already occupied`` error in ``PriorityScheduler`` by adjusting
+  the condition for filled slots in ``_get_filled_indices()``. This was primarily
+  an issue for blocks with ``duration`` <= ``time_resolution``. [#550]
 
 0.10.1 (2024-08-13)
 -------------------

--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -5,6 +5,7 @@ Tools for scheduling observations.
 
 import copy
 from abc import ABCMeta, abstractmethod
+import warnings
 
 import numpy as np
 
@@ -15,6 +16,7 @@ from astropy.table import Table
 from .utils import time_grid_from_range, stride_array
 from .constraints import AltitudeConstraint
 from .target import get_skycoord
+from .exceptions import AstroplanWarning
 
 __all__ = ['ObservingBlock', 'TransitionBlock', 'Schedule', 'Slot',
            'Scheduler', 'SequentialScheduler', 'PriorityScheduler',
@@ -702,11 +704,19 @@ class PriorityScheduler(Scheduler):
 
     def _get_filled_indices(self, times):
         is_open_time = np.ones(len(times), bool)
+        times_resolution = np.min(np.diff(times))
         # close times that are already filled
         pre_filled = np.array([[block.start_time, block.end_time] for
                                block in self.schedule.scheduled_blocks if
                                isinstance(block, ObservingBlock)])
         for start_end in pre_filled:
+            if np.diff(start_end)[0] <= times_resolution:
+                warnings.warn(
+                    "Unexpected behavior may occur when the time "
+                    f"resolution ({times_resolution.to(u.second)}) "
+                    "is not smaller than the block duration "
+                    f"({np.diff(start_end)[0].to(u.second)}).", AstroplanWarning
+                )
             filled = np.where((start_end[0]-0.5*u.second < times) & (times < start_end[1]))
             is_open_time[filled[0]] = False
         return is_open_time

--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -704,13 +704,13 @@ class PriorityScheduler(Scheduler):
 
     def _get_filled_indices(self, times):
         is_open_time = np.ones(len(times), bool)
-        times_resolution = np.min(np.diff(times))
+        times_resolution = np.min(times[1:] - times[:-1])
         # close times that are already filled
         pre_filled = np.array([[block.start_time, block.end_time] for
                                block in self.schedule.scheduled_blocks if
                                isinstance(block, ObservingBlock)])
         for start_end in pre_filled:
-            if np.diff(start_end)[0] <= times_resolution:
+            if start_end[1] - start_end[0] <= times_resolution:
                 warnings.warn(
                     "Unexpected behavior may occur when the time "
                     f"resolution ({times_resolution.to(u.second)}) "

--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -707,10 +707,8 @@ class PriorityScheduler(Scheduler):
                                block in self.schedule.scheduled_blocks if
                                isinstance(block, ObservingBlock)])
         for start_end in pre_filled:
-            filled = np.where((start_end[0] < times) & (times < start_end[1]))
-            if len(filled[0]) > 0:
-                is_open_time[filled[0]] = False
-                is_open_time[min(filled[0]) - 1] = False
+            filled = np.where((start_end[0]-0.5*u.second < times) & (times < start_end[1]))
+            is_open_time[filled[0]] = False
         return is_open_time
 
     def _make_schedule(self, blocks):


### PR DESCRIPTION
Previously, for blocks with a duration equal to the time_resolution, _get_filled_indices() was unable to identify overlapping slots. This was due to the comparison of start times not accounting for these specific cases.

This has been addressed by adjusting the start_time comparison to be slightly earlier (0.5 seconds). This change enables the correct identification of filled time slots for blocks with minimal duration, thus preventing the 'block already occupied' error.

Fixes #368