### PR TITLE
AltitudeConstraint: Adjust max_best_rescale() to prevent unexpected output

### DIFF
--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -354,7 +354,7 @@ class AltitudeConstraint(Constraint):
             uppermask = alt <= self.max
             return lowermask & uppermask
         else:
-            return max_best_rescale(alt, self.min, self.max)
+            return max_best_rescale(alt, self.min, self.max, greater_than_max=0)
 
 
 class AirmassConstraint(AltitudeConstraint):

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -98,6 +98,17 @@ def test_observability_table():
     assert 'time observable' in stab.colnames
 
 
+def test_altitude_constraint():
+    subaru = Observer.at_site("Subaru")
+    time = Time('2001-02-03 15:35:00')
+    time_range = Time([time, time+3*u.hour])
+
+    constraint = AltitudeConstraint(min=40*u.deg, max=50*u.deg, boolean_constraint=False)
+    results = constraint(subaru, vega, times=time_grid_from_range(time_range))
+    # Check if below min and above max values are 0
+    assert np.all([results != 0][0] == [False, False, True,  True,  False, False])
+
+
 def test_compare_altitude_constraint_and_observer():
     time = Time('2001-02-03 04:05:06')
     time_ranges = [Time([time, time+1*u.hour]) + offset


### PR DESCRIPTION
In previous versions, when setting the max parameter for altitude, max_best_rescale() would return 1.0 if the altitude exceeded the maximum limit. This behavior was unexpected.

To rectify this, the greater_than_max argument in max_best_rescale() has been set to 0. This adjustment ensures that the output aligns with expectations when the altitude surpasses the specified maximum constraint.