### PR TITLE
Replacing deprecated astropy function: get_moon

### DIFF
--- a/astroplan/conftest.py
+++ b/astroplan/conftest.py
@@ -15,8 +15,6 @@ except ImportError:  # In case this plugin is not installed
     PYTEST_HEADER_MODULES = {}
     TESTED_VERSIONS = {}
 
-from astropy.tests.helper import enable_deprecations_as_exceptions
-
 # We do this to pick up the test header report even when using LTS astropy
 try:
     from astropy.tests.pytest_plugins import pytest_report_header  # noqa
@@ -35,10 +33,6 @@ except ImportError:
 packagename = os.path.basename(os.path.dirname(__file__))
 TESTED_VERSIONS[packagename] = version
 
-
-# Comment out this line to avoid deprecation warnings being raised as
-# exceptions
-enable_deprecations_as_exceptions()
 
 # Define list of packages for which to display version numbers in the test log
 try:

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -16,7 +16,7 @@ import warnings
 # Third-party
 from astropy.time import Time
 import astropy.units as u
-from astropy.coordinates import get_body, get_sun, get_moon, Galactic, SkyCoord
+from astropy.coordinates import get_body, get_sun, Galactic, SkyCoord
 from astropy import table
 
 import numpy as np
@@ -590,7 +590,7 @@ class MoonSeparationConstraint(Constraint):
         self.ephemeris = ephemeris
 
     def compute_constraint(self, times, observer, targets):
-        moon = get_moon(times, location=observer.location, ephemeris=self.ephemeris)
+        moon = get_body("moon", times, location=observer.location, ephemeris=self.ephemeris)
         # note to future editors - the order matters here
         # moon.separation(targets) is NOT the same as targets.separation(moon)
         # the former calculates the separation in the frame of the moon coord

--- a/astroplan/moon.py
+++ b/astroplan/moon.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, print_function,
 
 # Third-party
 import numpy as np
-from astropy.coordinates import get_moon, get_sun
+from astropy.coordinates import get_sun, get_body
 
 __all__ = ["moon_phase_angle", "moon_illumination"]
 
@@ -35,7 +35,7 @@ def moon_phase_angle(time, ephemeris=None):
     # TODO: cache these sun/moon SkyCoord objects
 
     sun = get_sun(time)
-    moon = get_moon(time, ephemeris=ephemeris)
+    moon = get_body("moon", time, ephemeris=ephemeris)
     elongation = sun.separation(moon)
     return np.arctan2(sun.distance*np.sin(elongation),
                       moon.distance - sun.distance*np.cos(elongation))

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -9,7 +9,7 @@ import datetime
 import warnings
 # Third-party
 from astropy.coordinates import (EarthLocation, SkyCoord, AltAz, get_sun,
-                                 get_moon, Angle, Longitude)
+                                 get_body, Angle, Longitude)
 import astropy.units as u
 from astropy.time import Time
 from astropy.utils.exceptions import AstropyDeprecationWarning
@@ -513,7 +513,7 @@ class Observer(object):
         """
         if target is not None:
             if target is MoonFlag:
-                target = get_moon(time, location=self.location)
+                target = get_body("moon", time, location=self.location)
             elif target is SunFlag:
                 target = get_sun(time)
 
@@ -1734,7 +1734,7 @@ class Observer(object):
         if not isinstance(time, Time):
             time = Time(time)
 
-        moon = get_moon(time, location=self.location, ephemeris=ephemeris)
+        moon = get_body("moon", time, location=self.location, ephemeris=ephemeris)
         return self.altaz(time, moon)
 
     def sun_altaz(self, time):

--- a/astroplan/tests/test_constraints.py
+++ b/astroplan/tests/test_constraints.py
@@ -5,7 +5,7 @@ import datetime as dt
 import numpy as np
 import astropy.units as u
 from astropy.time import Time
-from astropy.coordinates import Galactic, SkyCoord, get_sun, get_moon
+from astropy.coordinates import Galactic, SkyCoord, get_sun, get_body
 from astropy.utils import minversion
 import pytest
 
@@ -193,7 +193,7 @@ def test_moon_separation():
     time = Time('2003-04-05 06:07:08')
     apo = Observer.at_site("APO")
     altaz_frame = apo.altaz(time)
-    moon = get_moon(time, apo.location).transform_to(altaz_frame)
+    moon = get_body("moon", time, apo.location).transform_to(altaz_frame)
     one_deg_away = SkyCoord(az=moon.az, alt=moon.alt+1*u.deg, frame=altaz_frame)
     five_deg_away = SkyCoord(az=moon.az+5*u.deg, alt=moon.alt,
                              frame=altaz_frame)

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -159,22 +159,27 @@ def test_rise_set_transit_nearest_vector():
     time = Time('2022-06-21 00:00:00')
 
     obs = Observer(location=location)
-    rise_vector = obs.target_rise_time(time, sc_list)
+
+    with pytest.warns(TargetAlwaysUpWarning):
+        rise_vector = obs.target_rise_time(time, sc_list)
+        polaris_rise = obs.target_rise_time(time, polaris)
+
     vega_rise = obs.target_rise_time(time, vega)
     mira_rise = obs.target_rise_time(time, mira)
     sirius_rise = obs.target_rise_time(time, sirius)
-    polaris_rise = obs.target_rise_time(time, polaris)
 
     assert rise_vector[0] == vega_rise
     assert rise_vector[1] == mira_rise
     assert rise_vector[2] == sirius_rise
     assert rise_vector[3].value.mask and polaris_rise.value.mask
 
-    set_vector = obs.target_set_time(time, sc_list)
+    with pytest.warns(TargetAlwaysUpWarning):
+        set_vector = obs.target_set_time(time, sc_list)
+        polaris_set = obs.target_set_time(time, polaris)
+
     vega_set = obs.target_set_time(time, vega)
     mira_set = obs.target_set_time(time, mira)
     sirius_set = obs.target_set_time(time, sirius)
-    polaris_set = obs.target_set_time(time, polaris)
 
     assert set_vector[0] == vega_set
     assert set_vector[1] == mira_set


### PR DESCRIPTION
Fixes #557

Astropy has deprecated `get_moon(time...)` in favor of `get_body('moon', time...)`. This pull request changes those calls, and catches some expected warnings in the test matrix.