### PR TITLE
Add __hash__, __eq__, and __ne__ support for Observer objects

### DIFF
--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -290,7 +290,7 @@ class Observer(object):
         >>> keck._key()
         ('Keck', None, None, None, <Longitude -155.47833333 deg>,
             <Latitude 19.82833333 deg>, <Quantity 4160. m>,
-            <DstTzInfo 'US/Hawaii' LMT-1 day, 13:29:00 STD>)        
+            <DstTzInfo 'US/Hawaii' LMT-1 day, 13:29:00 STD>)
         """
 
         return (self.name,
@@ -311,7 +311,7 @@ class Observer(object):
 
         >>> from astroplan import Observer
         >>> keck = Observer.at_site("Keck", timezone="US/Hawaii")
-        >>> hash(keck)                                    
+        >>> hash(keck)
         -3872382927731250571
         """
 

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -273,6 +273,85 @@ class Observer(object):
                     attributes_strings.append("{}={}".format(name, value))
         return "<{}: {}>".format(class_name, ",\n    ".join(attributes_strings))
 
+    def _key(self):
+        """
+        Generate a tuple of the attributes that determine uniqueness of
+        `~astroplan.Observer` objects.
+
+        Returns
+        -------
+        key : tuple
+
+        Examples
+        --------
+
+        >>> from astroplan import Observer
+        >>> keck = Observer.at_site("Keck", timezone="US/Hawaii")
+        >>> keck._key()
+        ('Keck', None, None, None, <Longitude -155.47833333 deg>,
+            <Latitude 19.82833333 deg>, <Quantity 4160. m>,
+            <DstTzInfo 'US/Hawaii' LMT-1 day, 13:29:00 STD>)        
+        """
+
+        return (self.name,
+                self.pressure,
+                self.temperature,
+                self.relative_humidity,
+                self.longitude,
+                self.latitude,
+                self.elevation,
+                self.timezone,)
+
+    def __hash__(self):
+        """
+        Hash the `~astroplan.Observer` object.
+
+        Examples
+        --------
+
+        >>> from astroplan import Observer
+        >>> keck = Observer.at_site("Keck", timezone="US/Hawaii")
+        >>> hash(keck)                                    
+        -3872382927731250571
+        """
+
+        return hash(self._key())
+
+    def __eq__(self, other):
+        """
+        Equality check for `~astroplan.Observer` objects.
+
+        Examples
+        --------
+
+        >>> from astroplan import Observer
+        >>> keck = Observer.at_site("Keck", timezone="US/Hawaii")
+        >>> keck2 = Observer.at_site("Keck", timezone="US/Hawaii")
+        >>> keck == keck2
+        True
+        """
+
+        if isinstance(other, Observer):
+            return self._key() == other._key()
+        else:
+            return NotImplemented
+
+    def __ne__(self, other):
+        """
+        Inequality check for `~astroplan.Observer` objects.
+
+        Examples
+        --------
+
+        >>> from astroplan import Observer
+        >>> keck = Observer.at_site("Keck", timezone="US/Hawaii")
+        >>> kpno = Observer.at_site("KPNO", timezone="US/Arizona")
+        >>> keck != kpno
+        True
+        """
+
+        return not self.__eq__(other)
+
     @classmethod
     def at_site(cls, site_name, **kwargs):
         """

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -1358,3 +1358,30 @@ def test_observer_lon_lat_el():
     obs = Observer.at_site('Subaru')
     for attr in ['longitude', 'latitude', 'elevation']:
         assert hasattr(obs, attr)
+
+def test_hash_observer():
+    """Test that Observer objects are hashable."""
+    obs1 = Observer.at_site('Subaru')
+    obs2 = Observer.at_site('Subaru')
+    assert hash(obs1) == hash(obs2)
+
+    obs3 = Observer.at_site('Keck', timezone='US/Hawaii')
+    assert hash(obs1) != hash(obs3)
+
+    obs4 = Observer.at_site('Keck', timezone='US/Hawaii')
+    assert hash(obs3) == hash(obs4)
+    
+def test_eq_observer():
+    """Test that Observer objects are comparable."""
+    obs1 = Observer.at_site('Subaru')
+    obs2 = Observer.at_site('Subaru')
+    assert obs1 == obs2
+
+    obs3 = Observer.at_site('Keck')
+    assert obs1 != obs3
+
+    obs4 = Observer.at_site('Subaru', timezone='US/Hawaii')
+    assert obs1 != obs4
+
+    obs5 = Observer.at_site('Subaru', timezone='US/Hawaii')
+    assert obs4 == obs5

--- a/astroplan/tests/test_observer.py
+++ b/astroplan/tests/test_observer.py
@@ -1359,6 +1359,7 @@ def test_observer_lon_lat_el():
     for attr in ['longitude', 'latitude', 'elevation']:
         assert hasattr(obs, attr)
 
+
 def test_hash_observer():
     """Test that Observer objects are hashable."""
     obs1 = Observer.at_site('Subaru')
@@ -1370,7 +1371,8 @@ def test_hash_observer():
 
     obs4 = Observer.at_site('Keck', timezone='US/Hawaii')
     assert hash(obs3) == hash(obs4)
-    
+
+
 def test_eq_observer():
     """Test that Observer objects are comparable."""
     obs1 = Observer.at_site('Subaru')


### PR DESCRIPTION
Adds the ability to hash and compare Observer objects. This is helpful for adding LRU cache decorators to functions that take an Observer as a parameter.