### PR TITLE
Convert FixedTargets passed to `get_body` into SkyCoords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,10 @@
-0.9 (unreleased)
+0.9.1 (unreleased)
+------------------
+
+- Fix bug when ``FixedTarget`` objects are passed to methods that calculate
+  lunar coordinates. [#568]
+
+0.9 (2023-07-27)
 ----------------
 
 - Fix time range in ``months_observable`` to not be only in 2014. Function now

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -550,6 +550,7 @@ class SunSeparationConstraint(Constraint):
         # by the observer.
         # 'get_sun' returns ICRS coords.
         sun = get_body('sun', times, location=observer.location)
+        targets = get_skycoord(targets)
         solar_separation = sun.separation(targets)
 
         if self.min is None and self.max is not None:
@@ -595,6 +596,7 @@ class MoonSeparationConstraint(Constraint):
         # moon.separation(targets) is NOT the same as targets.separation(moon)
         # the former calculates the separation in the frame of the moon coord
         # which is GCRS, and that is what we want.
+        targets = get_skycoord(targets)
         moon_separation = moon.separation(targets)
 
         if self.min is None and self.max is not None:


### PR DESCRIPTION
@pmaxted reported in #567 that when a (list of) `FixedTarget` is passed to methods that calculate lunar coordinates, the calls to `get_body` introduced in #558 must convert those `FixedTarget`s to `SkyCoords` before computing separations. This oversight wasn't noticed in the tests because the relevant tests rely on SkyCoords.

This PR calls `get_skycoords` before passing the `targets` to `get_body`.

Fixes #567