### PR TITLE
Drop wheel from build system requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,4 @@
 [build-system]
 requires = ["setuptools",
-            "setuptools_scm",
-            "wheel"]
+            "setuptools_scm"]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
The latest documentation from setuptools does not say that this is a recommended or required dependency.