### PR TITLE
Add type hints

### DIFF
--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function,
 
 # Standard library
 from abc import ABCMeta, abstractmethod
-from typing import Optional, Sequence, Union
+from typing import Optional, Self, Sequence, Union
 import datetime
 import time
 import warnings
@@ -444,21 +444,21 @@ class AtNightConstraint(Constraint):
         self.force_pressure_zero = force_pressure_zero
 
     @classmethod
-    def twilight_civil(cls, **kwargs) -> "AtNightConstraint":
+    def twilight_civil(cls, **kwargs) -> Self:
         """
         Consider nighttime as time between civil twilights (-6 degrees).
         """
         return cls(max_solar_altitude=-6*u.deg, **kwargs)
 
     @classmethod
-    def twilight_nautical(cls, **kwargs) -> "AtNightConstraint":
+    def twilight_nautical(cls, **kwargs) -> Self:
         """
         Consider nighttime as time between nautical twilights (-12 degrees).
         """
         return cls(max_solar_altitude=-12*u.deg, **kwargs)
 
     @classmethod
-    def twilight_astronomical(cls, **kwargs) -> "AtNightConstraint":
+    def twilight_astronomical(cls, **kwargs) -> Self:
         """
         Consider nighttime as time between astronomical twilights (-18 degrees).
         """
@@ -645,7 +645,7 @@ class MoonIlluminationConstraint(Constraint):
         self.ephemeris = ephemeris
 
     @classmethod
-    def dark(cls, min: Optional[float] = None, max: Optional[float] = 0.25, **kwargs) -> "MoonIlluminationConstraint":
+    def dark(cls, min: Optional[float] = None, max: Optional[float] = 0.25, **kwargs) -> Self:
         """
         initialize a `~astroplan.constraints.MoonIlluminationConstraint`
         with defaults of no minimum and a maximum of 0.25
@@ -662,7 +662,7 @@ class MoonIlluminationConstraint(Constraint):
         return cls(min, max, **kwargs)
 
     @classmethod
-    def grey(cls, min: Optional[float] = 0.25, max: Optional[float] = 0.65, **kwargs) -> "MoonIlluminationConstraint":
+    def grey(cls, min: Optional[float] = 0.25, max: Optional[float] = 0.65, **kwargs) -> Self:
         """
         initialize a `~astroplan.constraints.MoonIlluminationConstraint`
         with defaults of a minimum of 0.25 and a maximum of 0.65
@@ -679,7 +679,7 @@ class MoonIlluminationConstraint(Constraint):
         return cls(min, max, **kwargs)
 
     @classmethod
-    def bright(cls, min: Optional[float] = 0.65, max: Optional[float] = None, **kwargs) -> "MoonIlluminationConstraint":
+    def bright(cls, min: Optional[float] = 0.65, max: Optional[float] = None, **kwargs) -> Self:
         """
         initialize a `~astroplan.constraints.MoonIlluminationConstraint`
         with defaults of a minimum of 0.65 and no maximum

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -230,7 +230,7 @@ class Constraint(object):
     __metaclass__ = ABCMeta
 
     def __call__(self, observer: Observer, targets: Sequence[FixedTarget], times: Optional[Time] = None,
-                 time_range: Optional[Time] = None, time_grid_resolution: Quantity["time"] = 0.5*u.hour,
+                 time_range: Optional[Time] = None, time_grid_resolution: Quantity = 0.5*u.hour,
                  grid_times_targets: bool = False) -> np.ndarray[Union[float, bool]]:
         """
         Compute the constraint for this class
@@ -340,7 +340,7 @@ class AltitudeConstraint(Constraint):
         float on [0, 1], where 0 is the min altitude and 1 is the max.
     """
 
-    def __init__(self, min: Optional[Quantity["angle"]] = None, max: Optional[Quantity["angle"]] = None, boolean_constraint: bool = True):  # noqa: F821
+    def __init__(self, min: Optional[Quantity] = None, max: Optional[Quantity] = None, boolean_constraint: bool = True):
         if min is None:
             self.min = -90*u.deg
         else:
@@ -427,7 +427,7 @@ class AtNightConstraint(Constraint):
     Constrain the Sun to be below ``horizon``.
     """
     @u.quantity_input(horizon=u.deg)
-    def __init__(self, max_solar_altitude: Quantity["angle"] = 0*u.deg, force_pressure_zero: bool = True):  # noqa: F821
+    def __init__(self, max_solar_altitude: Quantity = 0*u.deg, force_pressure_zero: bool = True):
         """
         Parameters
         ----------
@@ -464,7 +464,7 @@ class AtNightConstraint(Constraint):
         """
         return cls(max_solar_altitude=-18*u.deg, **kwargs)
 
-    def _get_solar_altitudes(self, times: Time, observer: Observer, targets: Sequence[FixedTarget]) -> Quantity["angle"]:  # noqa: F821
+    def _get_solar_altitudes(self, times: Time, observer: Observer, targets: Sequence[FixedTarget]) -> Quantity:
         if not hasattr(observer, '_altaz_cache'):
             observer._altaz_cache = {}
 
@@ -501,7 +501,7 @@ class GalacticLatitudeConstraint(Constraint):
     Constrain the distance between the Galactic plane and some targets.
     """
 
-    def __init__(self, min: Optional[Quantity["angle"]] = None, max: Optional[Quantity["angle"]] = None):  # noqa: F821
+    def __init__(self, min: Optional[Quantity] = None, max: Optional[Quantity] = None):
         """
         Parameters
         ----------
@@ -535,7 +535,7 @@ class SunSeparationConstraint(Constraint):
     Constrain the distance between the Sun and some targets.
     """
 
-    def __init__(self, min: Optional[Quantity["angle"]] = None, max: Optional[Quantity["angle"]] = None):  # noqa: F821
+    def __init__(self, min: Optional[Quantity] = None, max: Optional[Quantity] = None):
         """
         Parameters
         ----------
@@ -577,7 +577,7 @@ class MoonSeparationConstraint(Constraint):
     Constrain the distance between the Earth's moon and some targets.
     """
 
-    def __init__(self, min: Optional[Quantity["angle"]] = None, max: Optional[Quantity["angle"]] = None, ephemeris: Optional[str] = None):  # noqa: F821
+    def __init__(self, min: Optional[Quantity] = None, max: Optional[Quantity] = None, ephemeris: Optional[str] = None):
         """
         Parameters
         ----------
@@ -946,7 +946,7 @@ class PhaseConstraint(Constraint):
 
 def is_always_observable(constraints: Union[list[Constraint], Constraint], observer: Observer,
                          targets: Union[list[FixedTarget], SkyCoord], times: Optional[Time] = None,
-                         time_range: Optional[Time] = None, time_grid_resolution: Quantity["time"] = 0.5*u.hour) -> list[bool]:
+                         time_range: Optional[Time] = None, time_grid_resolution: Quantity = 0.5*u.hour) -> list[bool]:
     """
     A function to determine whether ``targets`` are always observable throughout
     ``time_range`` given constraints in the ``constraints_list`` for a
@@ -997,7 +997,7 @@ def is_always_observable(constraints: Union[list[Constraint], Constraint], obser
 
 def is_observable(constraints: Union[list[Constraint], Constraint], observer: Observer,
                   targets: Union[list[FixedTarget], SkyCoord], times: Optional[Time] = None,
-                  time_range: Optional[Time] = None, time_grid_resolution: Quantity["time"] = 0.5*u.hour) -> list[bool]:
+                  time_range: Optional[Time] = None, time_grid_resolution: Quantity = 0.5*u.hour) -> list[bool]:
     """
     Determines if the ``targets`` are observable during ``time_range`` given
     constraints in ``constraints_list`` for a particular ``observer``.
@@ -1102,7 +1102,7 @@ def is_event_observable(constraints: Union[list[Constraint], Constraint],
 
 def months_observable(constraints: Union[list[Constraint], Constraint], observer: Observer,
                   targets: Union[list[FixedTarget], SkyCoord], time_range: Time = _current_year_time_range,
-                  time_grid_resolution: Quantity["time"] = 0.5*u.hour) -> list[set[int]]:
+                  time_grid_resolution: Quantity = 0.5*u.hour) -> list[set[int]]:
     """
     Determines which month the specified ``targets`` are observable for a
     specific ``observer``, given the supplied ``constraints``.
@@ -1171,7 +1171,7 @@ def months_observable(constraints: Union[list[Constraint], Constraint], observer
 
 def observability_table(constraints: Union[list[Constraint], Constraint], observer: Observer,
                   targets: Union[list[FixedTarget], SkyCoord], times: Optional[Time] = None,
-                  time_range: Optional[Time] = None, time_grid_resolution: Quantity["time"] = 0.5*u.hour) -> table.Table:
+                  time_range: Optional[Time] = None, time_grid_resolution: Quantity = 0.5*u.hour) -> table.Table:
     """
     Creates a table with information about observability for all  the ``targets``
     over the requested ``time_range``, given the constraints in

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -9,23 +9,28 @@ from __future__ import (absolute_import, division, print_function,
 
 # Standard library
 from abc import ABCMeta, abstractmethod
+from typing import Optional, Sequence, Union
 import datetime
 import time
 import warnings
 
 # Third-party
 from astropy.time import Time
+from astropy.units import Quantity
 import astropy.units as u
-from astropy.coordinates import get_body, get_sun, Galactic, SkyCoord
+from astropy.coordinates import get_body, get_sun, Galactic, SkyCoord, AltAz
 from astropy import table
 
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
+from numpy.typing import ArrayLike
 
 # Package
 from .moon import moon_illumination
+from .periodic import EclipsingSystem, PeriodicEvent
 from .utils import time_grid_from_range
-from .target import get_skycoord
+from .observer import Observer
+from .target import get_skycoord, FixedTarget
 from .exceptions import MissingConstraintWarning
 
 __all__ = ["AltitudeConstraint", "AirmassConstraint", "AtNightConstraint",
@@ -44,7 +49,7 @@ _current_year_time_range = Time(  # needed for backward compatibility
 )
 
 
-def _make_cache_key(times, targets):
+def _make_cache_key(times: Time, targets: Union[SkyCoord, list[FixedTarget]]) -> tuple:
     """
     Make a unique key to reference this combination of ``times`` and ``targets``.
 
@@ -85,7 +90,8 @@ def _make_cache_key(times, targets):
     return timekey + targkey
 
 
-def _get_altaz(times, observer, targets, force_zero_pressure=False):
+def _get_altaz(times: Time, observer: Observer, targets: Union[list[FixedTarget], SkyCoord],
+               force_zero_pressure: bool = False) -> dict[str, Union[Time, AltAz]]:
     """
     Calculate alt/az for ``target`` at times linearly spaced between
     the two times in ``time_range`` with grid spacing ``time_resolution``
@@ -133,7 +139,7 @@ def _get_altaz(times, observer, targets, force_zero_pressure=False):
     return observer._altaz_cache[aakey]
 
 
-def _get_moon_data(times, observer, force_zero_pressure=False):
+def _get_moon_data(times: Time, observer: Observer, force_zero_pressure: bool = False) -> dict[str, Union[Time, AltAz, np.ndarray]]:
     """
     Calculate moon altitude az and illumination for an array of times for
     ``observer``.
@@ -181,7 +187,7 @@ def _get_moon_data(times, observer, force_zero_pressure=False):
     return observer._moon_cache[aakey]
 
 
-def _get_meridian_transit_times(times, observer, targets):
+def _get_meridian_transit_times(times: Time, observer: Observer, targets: Union[list[FixedTarget], SkyCoord]) -> dict[str, Time]:
     """
     Calculate next meridian transit for an array of times for ``targets`` and
     ``observer``.
@@ -223,9 +229,9 @@ class Constraint(object):
     """
     __metaclass__ = ABCMeta
 
-    def __call__(self, observer, targets, times=None,
-                 time_range=None, time_grid_resolution=0.5*u.hour,
-                 grid_times_targets=False):
+    def __call__(self, observer: Observer, targets: Sequence[FixedTarget], times: Optional[Time] = None,
+                 time_range: Optional[Time] = None, time_grid_resolution: Quantity["time"] = 0.5*u.hour,
+                 grid_times_targets: bool = False) -> np.ndarray[Union[float, bool]]:
         """
         Compute the constraint for this class
 
@@ -289,7 +295,7 @@ class Constraint(object):
         return result
 
     @abstractmethod
-    def compute_constraint(self, times, observer, targets):
+    def compute_constraint(self, times: Time, observer: Observer, targets: Sequence[FixedTarget]) -> np.ndarray[Union[float, bool]]:
         """
         Actually do the real work of computing the constraint.  Subclasses
         override this.
@@ -334,7 +340,7 @@ class AltitudeConstraint(Constraint):
         float on [0, 1], where 0 is the min altitude and 1 is the max.
     """
 
-    def __init__(self, min=None, max=None, boolean_constraint=True):
+    def __init__(self, min: Optional[Quantity["angle"]] = None, max: Optional[Quantity["angle"]] = None, boolean_constraint: bool = True):  # noqa: F821
         if min is None:
             self.min = -90*u.deg
         else:
@@ -346,7 +352,7 @@ class AltitudeConstraint(Constraint):
 
         self.boolean_constraint = boolean_constraint
 
-    def compute_constraint(self, times, observer, targets):
+    def compute_constraint(self, times: Time, observer: Observer, targets: Sequence[FixedTarget]) -> np.ndarray[Union[float, bool]]:
         cached_altaz = _get_altaz(times, observer, targets)
         alt = cached_altaz['altaz'].alt
         if self.boolean_constraint:
@@ -386,12 +392,12 @@ class AirmassConstraint(AltitudeConstraint):
         AirmassConstraint(2)
     """
 
-    def __init__(self, max=None, min=1, boolean_constraint=True):
+    def __init__(self, max: Optional[float] = None, min: Optional[float] = 1.0, boolean_constraint: bool = True):
         self.min = min
         self.max = max
         self.boolean_constraint = boolean_constraint
 
-    def compute_constraint(self, times, observer, targets):
+    def compute_constraint(self, times: Time, observer: Observer, targets: Sequence[FixedTarget]) -> np.ndarray[Union[float, bool]]:
         cached_altaz = _get_altaz(times, observer, targets)
         secz = cached_altaz['altaz'].secz.value
         if self.boolean_constraint:
@@ -421,7 +427,7 @@ class AtNightConstraint(Constraint):
     Constrain the Sun to be below ``horizon``.
     """
     @u.quantity_input(horizon=u.deg)
-    def __init__(self, max_solar_altitude=0*u.deg, force_pressure_zero=True):
+    def __init__(self, max_solar_altitude: Quantity["angle"] = 0*u.deg, force_pressure_zero: bool = True):  # noqa: F821
         """
         Parameters
         ----------
@@ -438,27 +444,27 @@ class AtNightConstraint(Constraint):
         self.force_pressure_zero = force_pressure_zero
 
     @classmethod
-    def twilight_civil(cls, **kwargs):
+    def twilight_civil(cls, **kwargs) -> "AtNightConstraint":
         """
         Consider nighttime as time between civil twilights (-6 degrees).
         """
         return cls(max_solar_altitude=-6*u.deg, **kwargs)
 
     @classmethod
-    def twilight_nautical(cls, **kwargs):
+    def twilight_nautical(cls, **kwargs) -> "AtNightConstraint":
         """
         Consider nighttime as time between nautical twilights (-12 degrees).
         """
         return cls(max_solar_altitude=-12*u.deg, **kwargs)
 
     @classmethod
-    def twilight_astronomical(cls, **kwargs):
+    def twilight_astronomical(cls, **kwargs) -> "AtNightConstraint":
         """
         Consider nighttime as time between astronomical twilights (-18 degrees).
         """
         return cls(max_solar_altitude=-18*u.deg, **kwargs)
 
-    def _get_solar_altitudes(self, times, observer, targets):
+    def _get_solar_altitudes(self, times: Time, observer: Observer, targets: Sequence[FixedTarget]) -> Quantity["angle"]:  # noqa: F821
         if not hasattr(observer, '_altaz_cache'):
             observer._altaz_cache = {}
 
@@ -484,7 +490,7 @@ class AtNightConstraint(Constraint):
 
         return altitude
 
-    def compute_constraint(self, times, observer, targets):
+    def compute_constraint(self, times: Time, observer: Observer, targets: Sequence[FixedTarget]) -> np.ndarray[bool]:
         solar_altitude = self._get_solar_altitudes(times, observer, targets)
         mask = solar_altitude <= self.max_solar_altitude
         return mask
@@ -495,7 +501,7 @@ class GalacticLatitudeConstraint(Constraint):
     Constrain the distance between the Galactic plane and some targets.
     """
 
-    def __init__(self, min=None, max=None):
+    def __init__(self, min: Optional[Quantity["angle"]] = None, max: Optional[Quantity["angle"]] = None):  # noqa: F821
         """
         Parameters
         ----------
@@ -509,7 +515,7 @@ class GalacticLatitudeConstraint(Constraint):
         self.min = min
         self.max = max
 
-    def compute_constraint(self, times, observer, targets):
+    def compute_constraint(self, times: Time, observer: Observer, targets: Sequence[FixedTarget]) -> np.ndarray[bool]:
         separation = abs(targets.transform_to(Galactic).b)
 
         if self.min is None and self.max is not None:
@@ -529,7 +535,7 @@ class SunSeparationConstraint(Constraint):
     Constrain the distance between the Sun and some targets.
     """
 
-    def __init__(self, min=None, max=None):
+    def __init__(self, min: Optional[Quantity["angle"]] = None, max: Optional[Quantity["angle"]] = None):  # noqa: F821
         """
         Parameters
         ----------
@@ -543,7 +549,7 @@ class SunSeparationConstraint(Constraint):
         self.min = min
         self.max = max
 
-    def compute_constraint(self, times, observer, targets):
+    def compute_constraint(self, times: Time, observer: Observer, targets: Sequence[FixedTarget]) -> np.ndarray[bool]:
         # use get_body rather than get sun here, since
         # it returns the Sun's coordinates in an observer
         # centred frame, so the separation is as-seen
@@ -571,7 +577,7 @@ class MoonSeparationConstraint(Constraint):
     Constrain the distance between the Earth's moon and some targets.
     """
 
-    def __init__(self, min=None, max=None, ephemeris=None):
+    def __init__(self, min: Optional[Quantity["angle"]] = None, max: Optional[Quantity["angle"]] = None, ephemeris: Optional[str] = None):  # noqa: F821
         """
         Parameters
         ----------
@@ -590,7 +596,7 @@ class MoonSeparationConstraint(Constraint):
         self.max = max
         self.ephemeris = ephemeris
 
-    def compute_constraint(self, times, observer, targets):
+    def compute_constraint(self, times: Time, observer: Observer, targets: Sequence[FixedTarget]) -> np.ndarray[bool]:
         moon = get_body("moon", times, location=observer.location, ephemeris=self.ephemeris)
         # note to future editors - the order matters here
         # moon.separation(targets) is NOT the same as targets.separation(moon)
@@ -619,7 +625,7 @@ class MoonIlluminationConstraint(Constraint):
     Constraint is also satisfied if the Moon has set.
     """
 
-    def __init__(self, min=None, max=None, ephemeris=None):
+    def __init__(self, min: Optional[float] = None, max: Optional[float] = None, ephemeris: Optional[str] = None):
         """
         Parameters
         ----------
@@ -639,7 +645,7 @@ class MoonIlluminationConstraint(Constraint):
         self.ephemeris = ephemeris
 
     @classmethod
-    def dark(cls, min=None, max=0.25, **kwargs):
+    def dark(cls, min: Optional[float] = None, max: Optional[float] = 0.25, **kwargs) -> "MoonIlluminationConstraint":
         """
         initialize a `~astroplan.constraints.MoonIlluminationConstraint`
         with defaults of no minimum and a maximum of 0.25
@@ -656,7 +662,7 @@ class MoonIlluminationConstraint(Constraint):
         return cls(min, max, **kwargs)
 
     @classmethod
-    def grey(cls, min=0.25, max=0.65, **kwargs):
+    def grey(cls, min: Optional[float] = 0.25, max: Optional[float] = 0.65, **kwargs) -> "MoonIlluminationConstraint":
         """
         initialize a `~astroplan.constraints.MoonIlluminationConstraint`
         with defaults of a minimum of 0.25 and a maximum of 0.65
@@ -673,7 +679,7 @@ class MoonIlluminationConstraint(Constraint):
         return cls(min, max, **kwargs)
 
     @classmethod
-    def bright(cls, min=0.65, max=None, **kwargs):
+    def bright(cls, min: Optional[float] = 0.65, max: Optional[float] = None, **kwargs) -> "MoonIlluminationConstraint":
         """
         initialize a `~astroplan.constraints.MoonIlluminationConstraint`
         with defaults of a minimum of 0.65 and no maximum
@@ -689,7 +695,7 @@ class MoonIlluminationConstraint(Constraint):
         """
         return cls(min, max, **kwargs)
 
-    def compute_constraint(self, times, observer, targets):
+    def compute_constraint(self, times: Time, observer: Observer, targets: Sequence[FixedTarget]) -> np.ndarray[bool]:
         # first is the moon up?
         cached_moon = _get_moon_data(times, observer)
         moon_alt = cached_moon['altaz'].alt
@@ -716,7 +722,7 @@ class LocalTimeConstraint(Constraint):
     Constrain the observable hours.
     """
 
-    def __init__(self, min=None, max=None):
+    def __init__(self, min: Optional[datetime.time] = None, max: Optional[datetime.time] = None):
         """
         Parameters
         ----------
@@ -753,7 +759,7 @@ class LocalTimeConstraint(Constraint):
             if not isinstance(self.max, datetime.time):
                 raise TypeError("Time limits must be specified as datetime.time objects.")
 
-    def compute_constraint(self, times, observer, targets):
+    def compute_constraint(self, times: Time, observer: Observer, targets: Sequence[FixedTarget]) -> np.ndarray[bool]:
 
         timezone = None
 
@@ -804,7 +810,7 @@ class TimeConstraint(Constraint):
     to `is_observable` or `is_always_observable`.
     """
 
-    def __init__(self, min=None, max=None):
+    def __init__(self, min: Optional[Time] = None, max: Optional[Time] = None):
         """
         Parameters
         ----------
@@ -843,7 +849,7 @@ class TimeConstraint(Constraint):
                 raise TypeError("Time limits must be specified as "
                                 "astropy.time.Time objects.")
 
-    def compute_constraint(self, times, observer, targets):
+    def compute_constraint(self, times: Time, observer: Observer, targets: Sequence[FixedTarget]) -> np.ndarray[bool]:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
             min_time = Time("1950-01-01T00:00:00") if self.min is None else self.min
@@ -857,7 +863,7 @@ class PrimaryEclipseConstraint(Constraint):
     Constrain observations to times during primary eclipse.
     """
 
-    def __init__(self, eclipsing_system):
+    def __init__(self, eclipsing_system: EclipsingSystem):
         """
         Parameters
         ----------
@@ -876,7 +882,7 @@ class SecondaryEclipseConstraint(Constraint):
     Constrain observations to times during secondary eclipse.
     """
 
-    def __init__(self, eclipsing_system):
+    def __init__(self, eclipsing_system: EclipsingSystem):
         """
         Parameters
         ----------
@@ -885,7 +891,7 @@ class SecondaryEclipseConstraint(Constraint):
         """
         self.eclipsing_system = eclipsing_system
 
-    def compute_constraint(self, times, observer=None, targets=None):
+    def compute_constraint(self, times: Time, observer: Observer, targets: Sequence[FixedTarget]) -> np.ndarray[bool]:
         mask = self.eclipsing_system.in_secondary_eclipse(times)
         return mask
 
@@ -896,7 +902,7 @@ class PhaseConstraint(Constraint):
     (e.g.~transiting exoplanets, eclipsing binaries).
     """
 
-    def __init__(self, periodic_event, min=None, max=None):
+    def __init__(self, periodic_event: PeriodicEvent, min: Optional[float] = None, max: Optional[float] = None):
         """
         Parameters
         ----------
@@ -929,7 +935,7 @@ class PhaseConstraint(Constraint):
         self.min = min if min is not None else 0.0
         self.max = max if max is not None else 1.0
 
-    def compute_constraint(self, times, observer=None, targets=None):
+    def compute_constraint(self, times: Time, observer: Observer, targets: Sequence[FixedTarget]) -> np.ndarray[bool]:
         phase = self.periodic_event.phase(times)
 
         mask = np.where(self.max > self.min,
@@ -938,8 +944,9 @@ class PhaseConstraint(Constraint):
         return mask
 
 
-def is_always_observable(constraints, observer, targets, times=None,
-                         time_range=None, time_grid_resolution=0.5*u.hour):
+def is_always_observable(constraints: Union[list[Constraint], Constraint], observer: Observer,
+                         targets: Union[list[FixedTarget], SkyCoord], times: Optional[Time] = None,
+                         time_range: Optional[Time] = None, time_grid_resolution: Quantity["time"] = 0.5*u.hour) -> list[bool]:
     """
     A function to determine whether ``targets`` are always observable throughout
     ``time_range`` given constraints in the ``constraints_list`` for a
@@ -988,8 +995,9 @@ def is_always_observable(constraints, observer, targets, times=None,
     return np.all(constraint_arr, axis=1)
 
 
-def is_observable(constraints, observer, targets, times=None,
-                  time_range=None, time_grid_resolution=0.5*u.hour):
+def is_observable(constraints: Union[list[Constraint], Constraint], observer: Observer,
+                  targets: Union[list[FixedTarget], SkyCoord], times: Optional[Time] = None,
+                  time_range: Optional[Time] = None, time_grid_resolution: Quantity["time"] = 0.5*u.hour) -> list[bool]:
     """
     Determines if the ``targets`` are observable during ``time_range`` given
     constraints in ``constraints_list`` for a particular ``observer``.
@@ -1037,8 +1045,9 @@ def is_observable(constraints, observer, targets, times=None,
     return np.any(constraint_arr, axis=1)
 
 
-def is_event_observable(constraints, observer, target, times=None,
-                        times_ingress_egress=None):
+def is_event_observable(constraints: Union[list[Constraint], Constraint],
+                         observer: Observer, target: FixedTarget, times: Optional[Time] = None,
+                         times_ingress_egress: Optional[Time] = None) -> np.ndarray[bool]:
     """
     Determines if the ``target`` is observable at each time in ``times``, given
     constraints in ``constraints`` for a particular ``observer``.
@@ -1091,9 +1100,9 @@ def is_event_observable(constraints, observer, target, times=None,
     return constraint_arr
 
 
-def months_observable(constraints, observer, targets,
-                      time_range=_current_year_time_range,
-                      time_grid_resolution=0.5*u.hour):
+def months_observable(constraints: Union[list[Constraint], Constraint], observer: Observer,
+                  targets: Union[list[FixedTarget], SkyCoord], time_range: Time = _current_year_time_range,
+                  time_grid_resolution: Quantity["time"] = 0.5*u.hour) -> list[set[int]]:
     """
     Determines which month the specified ``targets`` are observable for a
     specific ``observer``, given the supplied ``constraints``.
@@ -1160,8 +1169,9 @@ def months_observable(constraints, observer, targets,
     return months_observable
 
 
-def observability_table(constraints, observer, targets, times=None,
-                        time_range=None, time_grid_resolution=0.5*u.hour):
+def observability_table(constraints: Union[list[Constraint], Constraint], observer: Observer,
+                  targets: Union[list[FixedTarget], SkyCoord], times: Optional[Time] = None,
+                  time_range: Optional[Time] = None, time_grid_resolution: Quantity["time"] = 0.5*u.hour) -> table.Table:
     """
     Creates a table with information about observability for all  the ``targets``
     over the requested ``time_range``, given the constraints in
@@ -1246,7 +1256,7 @@ def observability_table(constraints, observer, targets, times=None,
     return tab
 
 
-def min_best_rescale(vals, min_val, max_val, less_than_min=1):
+def min_best_rescale(vals: ArrayLike, min_val: float, max_val: float, less_than_min: int = 1):
     """
     rescales an input array ``vals`` to be a score (between zero and one),
     where the ``min_val`` goes to one, and the ``max_val`` goes to zero.
@@ -1290,7 +1300,7 @@ def min_best_rescale(vals, min_val, max_val, less_than_min=1):
     return rescaled
 
 
-def max_best_rescale(vals, min_val, max_val, greater_than_max=1):
+def max_best_rescale(vals: ArrayLike, min_val: float, max_val: float, greater_than_max: int = 1) -> ArrayLike:
     """
     rescales an input array ``vals`` to be a score (between zero and one),
     where the ``max_val`` goes to one, and the ``min_val`` goes to zero.

--- a/astroplan/moon.py
+++ b/astroplan/moon.py
@@ -6,14 +6,20 @@ This version of the `moon` module calculates lunar phase angle for a geocentric
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+# Standard library
+from typing import Optional
+
 # Third-party
 import numpy as np
 from astropy.coordinates import get_sun, get_body
+from astropy.time import Time
+import astropy.units as u
+from astropy.units import Quantity
 
 __all__ = ["moon_phase_angle", "moon_illumination"]
 
 
-def moon_phase_angle(time, ephemeris=None):
+def moon_phase_angle(time: Time, ephemeris: Optional[str] = None) -> Quantity[u.rad]:
     """
     Calculate lunar orbital phase in radians.
 
@@ -41,7 +47,7 @@ def moon_phase_angle(time, ephemeris=None):
                       moon.distance - sun.distance*np.cos(elongation))
 
 
-def moon_illumination(time, ephemeris=None):
+def moon_illumination(time: Time, ephemeris: Optional[str] = None) -> Quantity[u.rad]:
     """
     Calculate fraction of the moon illuminated.
 

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -32,7 +32,7 @@ MAGIC_TIME = Time(-999, format='jd')
 TargetType = Union[FixedTarget, SkyCoord, list[FixedTarget]]
 
 # Handle deprecated MAGIC_TIME variable
-def deprecation_wrap_module(mod: str, deprecated: Sequence[str]) -> Any:  # noqa: F821
+def deprecation_wrap_module(mod: str, deprecated: Sequence[str]) -> Any:
     """Return a wrapped object that warns about deprecated accesses"""
     deprecated = set(deprecated)
 
@@ -51,7 +51,7 @@ sys.modules[__name__] = deprecation_wrap_module(sys.modules[__name__],
                                                 deprecated=['MAGIC_TIME'])
 
 
-def _process_nans_in_jds(jds: Union[float, int, np.ndarray, Quantity["time"], Time]) -> np.ma.MaskedArray:  # noqa: F821
+def _process_nans_in_jds(jds: Union[float, int, np.ndarray, Quantity, Time]) -> np.ma.MaskedArray:
     """
     Some functions calculate times for events that won't happen, yielding nans. This wrapper
     manages vectors of (potentially) invalid JDs that must be passed to the astropy.time.Time
@@ -153,10 +153,10 @@ class Observer(object):
     """
     @u.quantity_input(elevation=u.m)
     def __init__(self, location: Optional[EarthLocation] = None, timezone: Union[str, datetime.tzinfo] = 'UTC',
-                 name: Optional[str] = None, latitude: Optional[Union[float, str, Quantity["angle"]]] = None,  # noqa: F821
-                 longitude: Optional[Union[float, str, Quantity["angle"]]] = None, elevation: Quantity["length"] = 0*u.m,  # noqa: F821
-                 pressure: Optional[Quantity["pressure"]] =None, relative_humidity: Optional[float] = None,  # noqa: F821
-                 temperature: Quantity["temperature"] = None, description: Optional[str] = None):  # noqa: F821
+                 name: Optional[str] = None, latitude: Optional[Union[float, str, Quantity]] = None,
+                 longitude: Optional[Union[float, str, Quantity]] = None, elevation: Quantity = 0*u.m,
+                 pressure: Optional[Quantity] =None, relative_humidity: Optional[float] = None,
+                 temperature: Quantity = None, description: Optional[str] = None):
         """
         Parameters
         ----------
@@ -229,17 +229,17 @@ class Observer(object):
                             'instance of datetime.tzinfo')
 
     @property
-    def longitude(self) -> Quantity["angle"]:  # noqa: F821
+    def longitude(self) -> Quantity:
         """The longitude of the observing location, derived from the location."""
         return self.location.lon
 
     @property
-    def latitude(self) -> Quantity["angle"]:  # noqa: F821
+    def latitude(self) -> Quantity:
         """The latitude of the observing location, derived from the location."""
         return self.location.lat
 
     @property
-    def elevation(self) -> Quantity["length"]:  # noqa: F821
+    def elevation(self) -> Quantity:
         """The elevation of the observing location with respect to sea level."""
         return self.location.height
 
@@ -538,7 +538,7 @@ class Observer(object):
         return time, target
 
     def altaz(self, time: Time, target: Optional[TargetType] = None,
-              obswl: Optional[Quantity["length"]] = None, grid_times_targets: bool = False) -> Union[AltAz, SkyCoord]:  # noqa: F821
+              obswl: Optional[Quantity] = None, grid_times_targets: bool = False) -> Union[AltAz, SkyCoord]:
         """
         Get an `~astropy.coordinates.AltAz` frame or coordinate.
 
@@ -671,9 +671,9 @@ class Observer(object):
 
     # Sun-related methods.
     @u.quantity_input(horizon=u.deg)
-    def _horiz_cross(self, t: Time, alt: Quantity["angle"], rise_set: str,  # noqa: F821
-                     horizon: Quantity["angle"] = 0*u.degree  # noqa: F821
-                     ) -> tuple[Union[Quantity["angle"], np.ndarray[float]]]:  # noqa: F821
+    def _horiz_cross(self, t: Time, alt: Quantity, rise_set: str,
+                     horizon: Quantity = 0*u.degree
+                     ) -> tuple[Union[Quantity, np.ndarray[float]]]:
         """
         Find time ``t`` when values in array ``a`` go from
         negative to positive or positive to negative (exclude endpoints)
@@ -781,8 +781,8 @@ class Observer(object):
 
     @u.quantity_input(horizon=u.deg)
     def _two_point_interp(self, jd_before: float, jd_after: float,
-                          alt_before: Quantity["angle"], alt_after: Quantity["angle"],  # noqa: F821
-                          horizon: Quantity["angle"] = 0*u.deg) -> Time:  # noqa: F821
+                          alt_before: Quantity, alt_after: Quantity,
+                          horizon: Quantity = 0*u.deg) -> Time:
         """
         Do linear interpolation between two ``altitudes`` at
         two ``times`` to determine the time where the altitude
@@ -823,7 +823,7 @@ class Observer(object):
         return np.squeeze(times)
 
     def _altitude_trig(self, LST: Time, target: Union[SkyCoord, FixedTarget],
-                       grid_times_targets: bool = False) -> Quantity["angle"]:  # noqa: F821
+                       grid_times_targets: bool = False) -> Quantity:
         """
         Calculate the altitude of ``target`` at local sidereal times ``LST``.
 
@@ -858,7 +858,7 @@ class Observer(object):
         return alt
 
     def _calc_riseset(self, time: Any, target: SkyCoord, prev_next: str, rise_set: str,
-                      horizon: Quantity["angle"], n_grid_points: int = 150,  # noqa: F821
+                      horizon: Quantity, n_grid_points: int = 150,
                       grid_times_targets: bool = False) -> Time:
         """
         Time at next rise/set of ``target``.
@@ -1059,7 +1059,7 @@ class Observer(object):
 
     @u.quantity_input(horizon=u.deg)
     def target_rise_time(self, time: Time, target: TargetType,
-                         which: str = 'nearest', horizon: Quantity["angle"] = 0*u.degree,  # noqa: F821
+                         which: str = 'nearest', horizon: Quantity = 0*u.degree,
                          grid_times_targets: bool = False, n_grid_points: int = 150) -> Time:
         """
         Calculate rise time.
@@ -1127,7 +1127,7 @@ class Observer(object):
 
     @u.quantity_input(horizon=u.deg)
     def target_set_time(self, time: Time, target: SkyCoord, which: str = 'nearest',
-                        horizon: Quantity["angle"] = 0*u.degree, grid_times_targets: bool = False,  # noqa: F821
+                        horizon: Quantity = 0*u.degree, grid_times_targets: bool = False,
                         n_grid_points: int = 150) -> Time:
         """
         Calculate set time.
@@ -1315,7 +1315,7 @@ class Observer(object):
                                                 grid_times_targets=grid_times_targets))
 
     @u.quantity_input(horizon=u.deg)
-    def sun_rise_time(self, time: Time, which: str = 'nearest', horizon: Quantity["angle"] = 0*u.degree,  # noqa: F821
+    def sun_rise_time(self, time: Time, which: str = 'nearest', horizon: Quantity = 0*u.degree,
                       n_grid_points: int = 150) -> Time:
         """
         Time of sunrise.
@@ -1367,7 +1367,7 @@ class Observer(object):
                                      n_grid_points=n_grid_points)
 
     @u.quantity_input(horizon=u.deg)
-    def sun_set_time(self, time: Time, which: str = 'nearest', horizon: Quantity["angle"] = 0*u.degree,  # noqa: F821
+    def sun_set_time(self, time: Time, which: str = 'nearest', horizon: Quantity = 0*u.degree,
                      n_grid_points: int = 150) -> Time:
         """
         Time of sunset.
@@ -1654,7 +1654,7 @@ class Observer(object):
 
     # Moon-related methods.
 
-    def moon_rise_time(self, time: Time, which: str = 'nearest', horizon: Quantity["angle"] = 0*u.deg,  # noqa: F821
+    def moon_rise_time(self, time: Time, which: str = 'nearest', horizon: Quantity = 0*u.deg,
                        n_grid_points: int = 150) -> Time:
         """
         Returns the local moon rise time.
@@ -1688,7 +1688,7 @@ class Observer(object):
         return self.target_rise_time(time, MoonFlag, which, horizon,
                                      n_grid_points=n_grid_points)
 
-    def moon_set_time(self, time: Time, which: str = 'nearest', horizon: Quantity["angle"] = 0*u.deg,  # noqa: F821
+    def moon_set_time(self, time: Time, which: str = 'nearest', horizon: Quantity = 0*u.deg,
                       n_grid_points: int = 150) -> Time:
         """
         Returns the local moon set time.
@@ -1756,7 +1756,7 @@ class Observer(object):
 
         return moon_illumination(time)
 
-    def moon_phase(self, time: Optional[Any] = None) -> Quantity["angle"]:  # noqa: F821
+    def moon_phase(self, time: Optional[Any] = None) -> Quantity:
         """
         Calculate lunar orbital phase.
 
@@ -1865,7 +1865,7 @@ class Observer(object):
         return self.altaz(time, sun)
 
     @u.quantity_input(horizon=u.deg)
-    def target_is_up(self, time: Any, target: TargetType, horizon: Quantity["angle"] = 0*u.degree,  # noqa: F821
+    def target_is_up(self, time: Any, target: TargetType, horizon: Quantity = 0*u.degree,
                      return_altaz: bool = False, grid_times_targets: bool = False) -> Union[bool, np.ndarray[bool]]:
         """
         Is ``target`` above ``horizon`` at this ``time``?
@@ -1931,8 +1931,8 @@ class Observer(object):
             return observable, altaz
 
     @u.quantity_input(horizon=u.deg)
-    def is_night(self, time: Any, horizon: Quantity["angle"] = 0*u.deg,  # noqa: F821
-                 obswl: Optional[Quantity["length"]] = None) -> Union[bool, np.ndarray[bool]]:  # noqa: F821
+    def is_night(self, time: Any, horizon: Quantity = 0*u.deg,
+                 obswl: Optional[Quantity] = None) -> Union[bool, np.ndarray[bool]]:
         """
         Is the Sun below ``horizon`` at ``time``?
 
@@ -2043,7 +2043,7 @@ class Observer(object):
         return Longitude(self.local_sidereal_time(time) - target.ra)
 
     @u.quantity_input(horizon=u.degree)
-    def tonight(self, time: Optional[Time] = None, horizon: Quantity["angle"] = 0 * u.degree, obswl: Optional[Quantity["length"]] =None):  # noqa: F821
+    def tonight(self, time: Optional[Time] = None, horizon: Quantity = 0 * u.degree, obswl: Optional[Quantity] =None):
         """
         Return a time range corresponding to the nearest night
 

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -5,7 +5,7 @@ from six import string_types
 
 # Standard library
 import sys
-from typing import Any, Callable, Optional, Sequence, Union
+from typing import Any, Callable, Optional, Self, Sequence, Union
 import datetime
 import warnings
 
@@ -359,7 +359,7 @@ class Observer(object):
         return not self.__eq__(other)
 
     @classmethod
-    def at_site(cls, site_name: str, **kwargs) -> "Observer":
+    def at_site(cls, site_name: str, **kwargs) -> Self:
         """
         Initialize an `~astroplan.observer.Observer` object with a site name.
 

--- a/astroplan/periodic.py
+++ b/astroplan/periodic.py
@@ -1,9 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+# Standard library
+from typing import Optional, Union
+
+# Third party
 import numpy as np
 import astropy.units as u
 from astropy.time import Time
+from astropy.units import Quantity
 
 __all__ = ['PeriodicEvent', 'EclipsingSystem']
 
@@ -13,7 +18,8 @@ class PeriodicEvent(object):
     A periodic event defined by an epoch and period.
     """
     @u.quantity_input(period=u.day, duration=u.day)
-    def __init__(self, epoch, period, duration=None, name=None):
+    def __init__(self, epoch: Time, period: Quantity["time"], duration: Optional[Quantity["time"]] = None,  # noqa: F821
+                 name: Optional[str] = None):
         """
 
         Parameters
@@ -32,7 +38,7 @@ class PeriodicEvent(object):
         self.name = name
         self.duration = duration
 
-    def phase(self, time):
+    def phase(self, time: Time) -> np.ndarray[float]:
         """
         Phase of periodic event, on interval [0, 1). For example, the phase
         could be an orbital phase for an eclipsing binary system.
@@ -66,8 +72,9 @@ class EclipsingSystem(PeriodicEvent):
         barycentric correction error (<=16 minutes).
     """
     @u.quantity_input(period=u.day, duration=u.day)
-    def __init__(self, primary_eclipse_time, orbital_period, duration=None,
-                 name=None, eccentricity=None, argument_of_periapsis=None):
+    def __init__(self, primary_eclipse_time: Time, orbital_period: Quantity["time"],  # noqa: F821
+                 duration: Optional[Quantity["time"]] = None, name: Optional[str] = None,  # noqa: F821
+                 eccentricity: Optional[float] = None, argument_of_periapsis: Optional[float] = None):
         """
         Parameters
         ----------
@@ -99,7 +106,7 @@ class EclipsingSystem(PeriodicEvent):
             argument_of_periapsis = np.pi/2
         self.argument_of_periapsis = argument_of_periapsis
 
-    def in_primary_eclipse(self, time):
+    def in_primary_eclipse(self, time: Time) -> Union[np.ndarray[bool], bool]:
         """
         Returns `True` when ``time`` is during a primary eclipse.
 
@@ -120,7 +127,7 @@ class EclipsingSystem(PeriodicEvent):
         return ((phases < float(self.duration/self.period)/2) |
                 (phases > 1 - float(self.duration/self.period)/2))
 
-    def in_secondary_eclipse(self, time):
+    def in_secondary_eclipse(self, time: Time) -> Union[np.ndarray[bool], bool]:
         r"""
         Returns `True` when ``time`` is during a secondary eclipse
 
@@ -161,7 +168,7 @@ class EclipsingSystem(PeriodicEvent):
         return ((phases < secondary_eclipse_phase + float(self.duration/self.period)/2) &
                 (phases > secondary_eclipse_phase - float(self.duration/self.period)/2))
 
-    def out_of_eclipse(self, time):
+    def out_of_eclipse(self, time: Time) -> Union[np.ndarray[bool], bool]:
         """
         Returns `True` when ``time`` is not during primary or secondary eclipse.
 
@@ -181,7 +188,7 @@ class EclipsingSystem(PeriodicEvent):
         return np.logical_not(np.logical_or(self.in_primary_eclipse(time),
                                             self.in_secondary_eclipse(time)))
 
-    def next_primary_eclipse_time(self, time, n_eclipses=1):
+    def next_primary_eclipse_time(self, time: Time, n_eclipses: int = 1) -> Time:
         """
         Time of the next primary eclipse after ``time``.
 
@@ -205,7 +212,7 @@ class EclipsingSystem(PeriodicEvent):
                          np.arange(n_eclipses) * self.period)
         return eclipse_times
 
-    def next_secondary_eclipse_time(self, time, n_eclipses=1):
+    def next_secondary_eclipse_time(self, time: Time, n_eclipses: int = 1) -> Time:
         """
         Time of the next secondary eclipse after ``time``.
 
@@ -234,7 +241,7 @@ class EclipsingSystem(PeriodicEvent):
                          np.arange(n_eclipses) * self.period)
         return eclipse_times
 
-    def next_primary_ingress_egress_time(self, time, n_eclipses=1):
+    def next_primary_ingress_egress_time(self, time: Time, n_eclipses: int = 1) -> Time:
         """
         Calculate the times of ingress and egress for the next ``n_eclipses``
         primary eclipses after ``time``
@@ -264,7 +271,7 @@ class EclipsingSystem(PeriodicEvent):
 
         return Time(ing_egr, format='jd', scale='utc')
 
-    def next_secondary_ingress_egress_time(self, time, n_eclipses=1):
+    def next_secondary_ingress_egress_time(self, time: Time, n_eclipses: int = 1) -> Time:
         """
         Calculate the times of ingress and egress for the next ``n_eclipses``
         secondary eclipses after ``time``

--- a/astroplan/periodic.py
+++ b/astroplan/periodic.py
@@ -18,7 +18,7 @@ class PeriodicEvent(object):
     A periodic event defined by an epoch and period.
     """
     @u.quantity_input(period=u.day, duration=u.day)
-    def __init__(self, epoch: Time, period: Quantity["time"], duration: Optional[Quantity["time"]] = None,  # noqa: F821
+    def __init__(self, epoch: Time, period: Quantity, duration: Optional[Quantity] = None,
                  name: Optional[str] = None):
         """
 
@@ -72,8 +72,8 @@ class EclipsingSystem(PeriodicEvent):
         barycentric correction error (<=16 minutes).
     """
     @u.quantity_input(period=u.day, duration=u.day)
-    def __init__(self, primary_eclipse_time: Time, orbital_period: Quantity["time"],  # noqa: F821
-                 duration: Optional[Quantity["time"]] = None, name: Optional[str] = None,  # noqa: F821
+    def __init__(self, primary_eclipse_time: Time, orbital_period: Quantity,
+                 duration: Optional[Quantity] = None, name: Optional[str] = None,
                  eccentricity: Optional[float] = None, argument_of_periapsis: Optional[float] = None):
         """
         Parameters

--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import copy
 from abc import ABCMeta, abstractmethod
-from typing import Optional, Sequence, Union
+from typing import Optional, Self, Sequence, Union
 
 import numpy as np
 from astropy import units as u
@@ -93,7 +93,7 @@ class ObservingBlock(object):
     def from_exposures(cls, target: FixedTarget, priority: Union[int, float],
                        time_per_exposure: Quantity, number_exposures: int,
                        readout_time: Quantity = 0 * u.second,
-                       configuration: dict = {}, constraints: Optional[list[Constraint]] = None) -> "ObservingBlock":
+                       configuration: dict = {}, constraints: Optional[list[Constraint]] = None) -> Self:
         duration = number_exposures * (time_per_exposure + readout_time)
         ob = cls(target, duration, priority, configuration, constraints)
         ob.time_per_exposure = time_per_exposure
@@ -222,7 +222,7 @@ class TransitionBlock(object):
 
     @classmethod
     @u.quantity_input(duration=u.second)
-    def from_duration(cls, duration: Quantity) -> "TransitionBlock":
+    def from_duration(cls, duration: Quantity) -> Self:
         # for testing how to put transitions between observations during
         # scheduling without considering the complexities of duration
         tb = TransitionBlock({'duration': duration})
@@ -584,7 +584,7 @@ class Scheduler(object):
 
     @classmethod
     @u.quantity_input(duration=u.second)
-    def from_timespan(cls, center_time: Time, duration: Union[Quantity, TimeDelta], **kwargs) -> "Scheduler":
+    def from_timespan(cls, center_time: Time, duration: Union[Quantity, TimeDelta], **kwargs) -> Self:
         """
         Create a new instance of this class given a center time and duration.
 

--- a/astroplan/scheduling.py
+++ b/astroplan/scheduling.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import copy
 from abc import ABCMeta, abstractmethod
-from typing import Optional, Sequence, Type, Union
+from typing import Optional, Sequence, Union
 
 import numpy as np
 from astropy import units as u
@@ -31,7 +31,7 @@ class ObservingBlock(object):
     constraints on observations.
     """
     @u.quantity_input(duration=u.second)
-    def __init__(self, target: FixedTarget, duration: Quantity["time"], priority: Union[int, float],  # noqa: F821
+    def __init__(self, target: FixedTarget, duration: Quantity, priority: Union[int, float],
                  configuration: dict = {}, constraints: Optional[list[Constraint]] =None,
                  name: Optional[Union[str, int]] = None):
         """
@@ -91,8 +91,8 @@ class ObservingBlock(object):
 
     @classmethod
     def from_exposures(cls, target: FixedTarget, priority: Union[int, float],
-                       time_per_exposure: Quantity["time"], number_exposures: int,  # noqa: F821
-                       readout_time: Quantity["time"] = 0 * u.second,  # noqa: F821
+                       time_per_exposure: Quantity, number_exposures: int,
+                       readout_time: Quantity = 0 * u.second,
                        configuration: dict = {}, constraints: Optional[list[Constraint]] = None) -> "ObservingBlock":
         duration = number_exposures * (time_per_exposure + readout_time)
         ob = cls(target, duration, priority, configuration, constraints)
@@ -128,7 +128,7 @@ class Scorer(object):
         self.global_constraints = global_constraints
         self.targets = get_skycoord([block.target for block in self.blocks])
 
-    def create_score_array(self, time_resolution: Quantity["time"] = 1*u.minute) -> np.ndarray:  # noqa: F821
+    def create_score_array(self, time_resolution: Quantity = 1*u.minute) -> np.ndarray:
         """
         this makes a score array over the entire schedule for all of the
         blocks and each `~astroplan.Constraint` in the .constraints of
@@ -177,7 +177,7 @@ class TransitionBlock(object):
     telescope is slewing, instrument is reconfiguring, etc.
     """
 
-    def __init__(self, components: dict[str, Quantity["time"]], start_time: Optional[Time] =None):  # noqa: F821
+    def __init__(self, components: dict[str, Quantity], start_time: Optional[Time] =None):
         """
         Parameters
         ----------
@@ -208,11 +208,11 @@ class TransitionBlock(object):
         return self.start_time + self.duration
 
     @property
-    def components(self) -> dict[str, Quantity["time"]]:  # noqa: F821
+    def components(self) -> dict[str, Quantity]:
         return self._components
 
     @components.setter
-    def components(self, val: dict[str, Quantity["time"]]) -> None:  # noqa: F821
+    def components(self, val: dict[str, Quantity]) -> None:
         duration = 0*u.second
         for t in val.values():
             duration += t
@@ -222,7 +222,7 @@ class TransitionBlock(object):
 
     @classmethod
     @u.quantity_input(duration=u.second)
-    def from_duration(cls, duration: Quantity["time"]) -> "TransitionBlock":  # noqa: F821
+    def from_duration(cls, duration: Quantity) -> "TransitionBlock":
         # for testing how to put transitions between observations during
         # scheduling without considering the complexities of duration
         tb = TransitionBlock({'duration': duration})
@@ -496,8 +496,8 @@ class Scheduler(object):
 
     @u.quantity_input(gap_time=u.second, time_resolution=u.second)
     def __init__(self, constraints: Sequence[Constraint], observer: Observer,
-                 transitioner: Optional["Transitioner"] = None, gap_time: Quantity["time"] = 5*u.min,  # noqa: F821
-                 time_resolution: Quantity["time"] = 20*u.second):  # noqa: F821
+                 transitioner: Optional["Transitioner"] = None, gap_time: Quantity = 5*u.min,
+                 time_resolution: Quantity = 20*u.second):
         """
         Parameters
         ----------
@@ -584,7 +584,7 @@ class Scheduler(object):
 
     @classmethod
     @u.quantity_input(duration=u.second)
-    def from_timespan(cls, center_time: Time, duration: Union[Quantity["time"], TimeDelta], **kwargs) -> "Scheduler":  # noqa: F821
+    def from_timespan(cls, center_time: Time, duration: Union[Quantity, TimeDelta], **kwargs) -> "Scheduler":
         """
         Create a new instance of this class given a center time and duration.
 
@@ -963,7 +963,7 @@ class Transitioner(object):
     u.quantity_input(slew_rate=u.deg/u.second)
 
     def __init__(self, slew_rate: Optional[Quantity["angular frequency"]] = None,  # noqa: F722
-                 instrument_reconfig_times: Optional[dict[str, dict[tuple[str, str], Quantity["time"]]]] = None):  # noqa: F722
+                 instrument_reconfig_times: Optional[dict[str, dict[tuple[str, str], Quantity]]] = None):  # noqa: F722
         """
         Parameters
         ----------
@@ -1024,7 +1024,7 @@ class Transitioner(object):
             return None
 
     def compute_instrument_transitions(self, oldblock: ObservingBlock,
-                                       newblock: ObservingBlock) -> dict[str, Quantity["time"]]:  # noqa: F821
+                                       newblock: ObservingBlock) -> dict[str, Quantity]:
         components = {}
         for conf_name, old_conf in oldblock.configuration.items():
             if conf_name in newblock.configuration:

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 # Standard library
 from abc import ABCMeta
-from typing import Optional, Union
+from typing import Optional, Self, Union
 
 # Third-party
 import astropy.units as u
@@ -110,7 +110,7 @@ class FixedTarget(Target):
         self.coord = coord
 
     @classmethod
-    def from_name(cls, query_name: str, name: Optional[str] = None, **kwargs) -> "FixedTarget":
+    def from_name(cls, query_name: str, name: Optional[str] = None, **kwargs) -> Self:
         """
         Initialize a `FixedTarget` by querying for a name from the CDS name
         resolver, using the machinery in
@@ -161,7 +161,7 @@ class FixedTarget(Target):
         return '<{} "{}" at {}>'.format(class_name, self.name, fmt_coord)
 
     @classmethod
-    def _from_name_mock(cls, query_name: str, name: Optional[str] = None) -> "FixedTarget":
+    def _from_name_mock(cls, query_name: str, name: Optional[str] = None) -> Self:
         """
         Mock method to replace `FixedTarget.from_name` in tests without
         internet connection.

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from typing import Any, Optional
+from typing import Optional
 
 # Standard library
 from abc import ABCMeta

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -1,12 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+from typing import Any, Optional
 
 # Standard library
 from abc import ABCMeta
 
 # Third-party
 import astropy.units as u
+from astropy.units import Quantity
 from astropy.coordinates import SkyCoord, ICRS, UnitSphericalRepresentation
 
 __all__ = ["Target", "FixedTarget", "NonFixedTarget"]
@@ -29,7 +31,8 @@ class Target(object):
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, name=None, ra=None, dec=None, marker=None):
+    def __init__(self, name: Optional[str] = None, ra: Optional[Quantity["angle"]] = None,  # noqa: F821
+                 dec: Optional[Quantity["angle"]] = None, marker: Optional[str] = None):  # noqa: F821
         """
         Defines a single observation target.
 
@@ -37,9 +40,9 @@ class Target(object):
         ----------
         name : str, optional
 
-        ra : WHAT TYPE IS ra ?
+        ra : Right ascension, optional
 
-        dec : WHAT TYPE IS dec ?
+        dec : Declination, optional
 
         marker : str, optional
             User-defined markers to differentiate between different types
@@ -48,7 +51,7 @@ class Target(object):
         raise NotImplementedError()
 
     @property
-    def ra(self):
+    def ra(self) -> Quantity["angle"]:  # noqa: F821
         """
         Right ascension.
         """
@@ -57,7 +60,7 @@ class Target(object):
         raise NotImplementedError()
 
     @property
-    def dec(self):
+    def dec(self) -> Quantity["angle"]:  # noqa: F821
         """
         Declination.
         """
@@ -88,7 +91,7 @@ class FixedTarget(Target):
     >>> sirius = FixedTarget.from_name("Sirius")
     """
 
-    def __init__(self, coord, name=None, **kwargs):
+    def __init__(self, coord: SkyCoord, name: Optional[str] = None, **kwargs):
         """
         Parameters
         ----------
@@ -107,7 +110,7 @@ class FixedTarget(Target):
         self.coord = coord
 
     @classmethod
-    def from_name(cls, query_name, name=None, **kwargs):
+    def from_name(cls, query_name: str, name: Optional[str] = None, **kwargs) -> "FixedTarget":
         """
         Initialize a `FixedTarget` by querying for a name from the CDS name
         resolver, using the machinery in
@@ -138,7 +141,7 @@ class FixedTarget(Target):
             name = query_name
         return cls(SkyCoord.from_name(query_name), name=name, **kwargs)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         String representation of `~astroplan.FixedTarget`.
 
@@ -158,7 +161,7 @@ class FixedTarget(Target):
         return '<{} "{}" at {}>'.format(class_name, self.name, fmt_coord)
 
     @classmethod
-    def _from_name_mock(cls, query_name, name=None):
+    def _from_name_mock(cls, query_name: str, name: Optional[str] = None) -> "FixedTarget":
         """
         Mock method to replace `FixedTarget.from_name` in tests without
         internet connection.
@@ -190,7 +193,7 @@ class NonFixedTarget(Target):
     """
 
 
-def get_skycoord(targets):
+def get_skycoord(targets: list[FixedTarget]) -> SkyCoord:
     """
     Return an `~astropy.coordinates.SkyCoord` object.
 

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -31,8 +31,8 @@ class Target(object):
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, name: Optional[str] = None, ra: Optional[Quantity["angle"]] = None,  # noqa: F821
-                 dec: Optional[Quantity["angle"]] = None, marker: Optional[str] = None):  # noqa: F821
+    def __init__(self, name: Optional[str] = None, ra: Optional[Quantity] = None,
+                 dec: Optional[Quantity] = None, marker: Optional[str] = None):
         """
         Defines a single observation target.
 
@@ -51,7 +51,7 @@ class Target(object):
         raise NotImplementedError()
 
     @property
-    def ra(self) -> Quantity["angle"]:  # noqa: F821
+    def ra(self) -> Quantity:
         """
         Right ascension.
         """
@@ -60,7 +60,7 @@ class Target(object):
         raise NotImplementedError()
 
     @property
-    def dec(self) -> Quantity["angle"]:  # noqa: F821
+    def dec(self) -> Quantity:
         """
         Declination.
         """

--- a/astroplan/target.py
+++ b/astroplan/target.py
@@ -1,10 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from typing import Optional
 
 # Standard library
 from abc import ABCMeta
+from typing import Optional, Union
 
 # Third-party
 import astropy.units as u
@@ -193,7 +193,7 @@ class NonFixedTarget(Target):
     """
 
 
-def get_skycoord(targets: list[FixedTarget]) -> SkyCoord:
+def get_skycoord(targets: Union[list[FixedTarget], FixedTarget, SkyCoord]) -> SkyCoord:
     """
     Return an `~astropy.coordinates.SkyCoord` object.
 

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -80,7 +80,7 @@ def download_IERS_A(show_progres: bool = True) -> None:
 
 
 @u.quantity_input(time_resolution=u.hour)
-def time_grid_from_range(time_range: Time, time_resolution: Quantity["time"] = 0.5*u.hour) -> Time:  # noqa: F821
+def time_grid_from_range(time_range: Time, time_resolution: Quantity = 0.5*u.hour) -> Time:
     """
     Get linearly-spaced sequence of times.
 

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -4,6 +4,8 @@ from __future__ import (absolute_import, division, print_function,
 
 # Standard library
 import warnings
+from typing import Union
+import os
 
 # Third-party
 import numpy as np
@@ -11,6 +13,8 @@ from astropy.utils.iers import IERS_Auto
 from astropy.time import Time
 import astropy.units as u
 from astropy.coordinates import EarthLocation
+from astropy.units import Quantity
+from numpy.typing import ArrayLike
 
 # Package
 from .exceptions import OldEarthOrientationDataWarning
@@ -30,7 +34,7 @@ IERS_A_WARNING = ("For best precision (on the order of arcseconds), you must "
 BACKUP_Time_get_delta_ut1_utc = Time._get_delta_ut1_utc
 
 
-def _low_precision_utc_to_ut1(self, jd1, jd2):
+def _low_precision_utc_to_ut1(self, jd1: np.ndarray[float], jd2: np.ndarray[float]) -> np.ndarray[float]:
     """
     When no IERS Bulletin A is available (no internet connection), use low
     precision time conversion by assuming UT1-UTC=0 always.
@@ -46,7 +50,7 @@ def _low_precision_utc_to_ut1(self, jd1, jd2):
         return np.zeros(self.shape)
 
 
-def download_IERS_A(show_progress=True):
+def download_IERS_A(show_progres: bool = True) -> None:
     """
     Download and cache the IERS Bulletin A table.
 
@@ -76,7 +80,7 @@ def download_IERS_A(show_progress=True):
 
 
 @u.quantity_input(time_resolution=u.hour)
-def time_grid_from_range(time_range, time_resolution=0.5*u.hour):
+def time_grid_from_range(time_range: Time, time_resolution: Quantity["time"] = 0.5*u.hour) -> Time:  # noqa: F821
     """
     Get linearly-spaced sequence of times.
 
@@ -151,7 +155,7 @@ def _unmock_remote_data():
     # otherwise assume it's already correct
 
 
-def _set_mpl_style_sheet(style_sheet):
+def _set_mpl_style_sheet(style_sheet: dict) -> None:
     """
     Import matplotlib, set the style sheet to ``style_sheet`` using
     the most backward compatible import pattern.
@@ -161,7 +165,7 @@ def _set_mpl_style_sheet(style_sheet):
     matplotlib.rcParams.update(style_sheet)
 
 
-def stride_array(arr, window_width):
+def stride_array(arr: ArrayLike, window_width: int) -> np.ndarray:
     """
     Computes all possible sequential subarrays of arr with length = window_width
 
@@ -194,7 +198,7 @@ class EarthLocation_mock(EarthLocation):
     """
 
     @classmethod
-    def of_site_mock(cls, string):
+    def of_site_mock(cls, string: str) -> EarthLocation:
         subaru = EarthLocation.from_geodetic(-155.4761111111111*u.deg,
                                              19.825555555555564*u.deg,
                                              4139*u.m)
@@ -233,7 +237,8 @@ class EarthLocation_mock(EarthLocation):
         return observatories[string.lower()]
 
 
-def _open_shelve(shelffn, withclosing=False):
+# NOTE: using dict as alias to avoid importing shelve above since they have similar properties
+def _open_shelve(shelffn: Union[str, os.PathLike], withclosing: bool = False) -> dict:
     """
     Opens a shelf file.  If ``withclosing`` is True, it will be opened with
     closing, allowing use like:


### PR DESCRIPTION
Hi! This adds type hints and fixes #592.

For astropy quantities, I used `Quantity` without any physical type or units annotations. The reasons are:

- This caused error when using `Union` with non-Quantity types (see https://github.com/astropy/astropy/issues/17017)
- In retrospect, this would have been equivalent to changing the behaviour of astroplan, by introducing new unit validation that was not present before this PR, which I think would have been out of scope anyways.

The tests are all passing on my machine.

I was not sure what the formatting guidelines were for this package. Let me know if there are issues on that side!