### PR TITLE
Fix some warnings in test

### DIFF
--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -551,7 +551,10 @@ class SunSeparationConstraint(Constraint):
         # 'get_sun' returns ICRS coords.
         sun = get_body('sun', times, location=observer.location)
         targets = get_skycoord(targets)
-        solar_separation = sun.separation(targets)
+        # sun.separation(targets) is NOT the same as targets.separation(sun)
+        # the former calculates the separation in the frame of the moon coord
+        # which is GCRS, and that is what we want.
+        solar_separation = sun.separation(targets, origin_mismatch="ignore")
 
         if self.min is None and self.max is not None:
             mask = self.max >= solar_separation
@@ -597,7 +600,7 @@ class MoonSeparationConstraint(Constraint):
         # the former calculates the separation in the frame of the moon coord
         # which is GCRS, and that is what we want.
         targets = get_skycoord(targets)
-        moon_separation = moon.separation(targets)
+        moon_separation = moon.separation(targets, origin_mismatch="ignore")
 
         if self.min is None and self.max is not None:
             mask = self.max >= moon_separation

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -158,7 +158,6 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
     if 'ls' not in style_kwargs and 'linestyle' not in style_kwargs:
         style_kwargs.setdefault('linestyle', '-')
 
-    time.to_datetime().utcoffset()
     if hasattr(time, 'utcoffset') and use_local_tz:
         tzoffset = time.utcoffset()
         tzname = time.tzname()

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -92,7 +92,7 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
         If None, uses the current ``Axes``.
 
     style_kwargs : dict or None, optional.
-        A dictionary of keywords passed into `~matplotlib.pyplot.plot_date`
+        A dictionary of keywords passed into `~matplotlib.pyplot.plot`
         to set plotting styles.
 
     style_sheet : dict or `None` (optional)
@@ -156,14 +156,16 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
     if 'lw' not in style_kwargs:
         style_kwargs.setdefault('linewidth', 1.5)
     if 'ls' not in style_kwargs and 'linestyle' not in style_kwargs:
-        style_kwargs.setdefault('fmt', '-')
+        style_kwargs.setdefault('linestyle', '-')
 
+    time.to_datetime().utcoffset()
     if hasattr(time, 'utcoffset') and use_local_tz:
         tzoffset = time.utcoffset()
         tzname = time.tzname()
         tzinfo = time.tzinfo
     else:
-        tzoffset = 0
+        # Add units to tzoffset so time_ut+tzoffset does not cause warning
+        tzoffset = 0 * u.second
         tzname = 'UTC'
         tzinfo = None
     # Populate time window if needed.
@@ -193,11 +195,11 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
             target_name = ''
 
         # Plot data (against timezone-offset time)
-        ax.plot_date(timetoplot.plot_date, masked_airmass, label=target_name, **style_kwargs)
+        ax.plot(timetoplot.datetime64, masked_airmass, label=target_name, **style_kwargs)
 
     # Format the time axis
     xlo, xhi = (timetoplot[0]), (timetoplot[-1])
-    ax.set_xlim([xlo.plot_date, xhi.plot_date])
+    ax.set_xlim([xlo.datetime64, xhi.datetime64])
     date_formatter = dates.DateFormatter('%H:%M')
     ax.xaxis.set_major_formatter(date_formatter)
     plt.setp(ax.get_xticklabels(), rotation=30, ha='right')
@@ -320,7 +322,7 @@ def plot_altitude(targets, observer, time, ax=None, style_kwargs=None,
         If None, uses the current ``Axes``.
 
     style_kwargs : dict or None, optional.
-        A dictionary of keywords passed into `~matplotlib.pyplot.plot_date`
+        A dictionary of keywords passed into `~matplotlib.pyplot.plot`
         to set plotting styles.
 
     style_sheet : dict or `None` (optional)
@@ -369,7 +371,7 @@ def plot_altitude(targets, observer, time, ax=None, style_kwargs=None,
     if style_kwargs is None:
         style_kwargs = {}
     style_kwargs = dict(style_kwargs)
-    if 'ls' not in style_kwargs and 'fmt' not in style_kwargs:
+    if 'ls' not in style_kwargs and 'linestyle' not in style_kwargs:
         style_kwargs.setdefault('linestyle', '-')
     if 'lw' not in style_kwargs:
         style_kwargs.setdefault('linewidth', 1.5)
@@ -399,10 +401,10 @@ def plot_altitude(targets, observer, time, ax=None, style_kwargs=None,
             target_name = ''
 
         # Plot data
-        ax.plot_date(time.plot_date, masked_altitude, label=target_name, **style_kwargs)
+        ax.plot(time.datetime64, masked_altitude, label=target_name, **style_kwargs)
 
     # Format the time axis
-    ax.set_xlim([time[0].plot_date, time[-1].plot_date])
+    ax.set_xlim([time[0].datetime64, time[-1].datetime64])
     date_formatter = dates.DateFormatter('%H:%M')
     ax.xaxis.set_major_formatter(date_formatter)
     plt.setp(ax.get_xticklabels(), rotation=30, ha='right')
@@ -510,17 +512,17 @@ def plot_schedule_airmass(schedule, show_night=False):
             next_twilight = schedule.observer.twilight_morning_astronomical(
                 midnight, which='next')
 
-            plt.axvspan(previous_sunset.plot_date, next_sunrise.plot_date,
+            plt.axvspan(previous_sunset.datetime64, next_sunrise.datetime64,
                         facecolor='lightgrey', alpha=0.05)
-            plt.axvspan(previous_twilight.plot_date, next_twilight.plot_date,
+            plt.axvspan(previous_twilight.datetime64, next_twilight.datetime64,
                         facecolor='lightgrey', alpha=0.05)
 
     for block in blocks:
         if hasattr(block, 'target'):
-            plt.axvspan(block.start_time.plot_date, block.end_time.plot_date,
+            plt.axvspan(block.start_time.datetime64, block.end_time.datetime64,
                         fc=targ_to_color[block.target.name], lw=0, alpha=.6)
         else:
-            plt.axvspan(block.start_time.plot_date, block.end_time.plot_date,
+            plt.axvspan(block.start_time.datetime64, block.end_time.datetime64,
                         color='k')
     plt.axhline(3, color='k', label='Transitions')
     # TODO: make this output a `axes` object
@@ -567,7 +569,7 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None,
         If None, uses the current ``Axes``.
 
     style_kwargs : dict or None, optional.
-        A dictionary of keywords passed into `~matplotlib.pyplot.plot_date`
+        A dictionary of keywords passed into `~matplotlib.pyplot.plot`
         to set plotting styles.
 
     style_sheet : dict or `None` (optional)
@@ -595,8 +597,7 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None,
     if style_kwargs is None:
         style_kwargs = {}
     style_kwargs = dict(style_kwargs)
-    style_kwargs.setdefault('fmt', '-')
-    if 'ls' not in style_kwargs and 'fmt' not in style_kwargs:
+    if 'ls' not in style_kwargs and 'linestyle' not in style_kwargs:
         style_kwargs.setdefault('linestyle', '-')
 
     # Populate time window if needed.
@@ -621,7 +622,7 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None,
     style_kwargs.setdefault('label', target_name)
 
     # Plot data.
-    ax.plot_date(time.plot_date, p_angle, **style_kwargs)
+    ax.plot(time.datetime64, p_angle, **style_kwargs)
 
     # Format the time axis
     date_formatter = dates.DateFormatter('%H:%M')

--- a/docs/faq/iers.rst
+++ b/docs/faq/iers.rst
@@ -107,9 +107,9 @@ astropy's IERS machinery:
     fig, ax = plt.subplots(figsize=(10,8))
     ax.axhline(0, color='gray', ls='--', lw=2)
 
-    ax.plot_date(time_range.plot_date,
+    ax.plot(time_range.datetime64,
                  DUT1_a, '-', lw=2, label='IERS Bulletin A + extrapolation')
-    ax.plot_date(time_range.plot_date[measurements_from_b],
+    ax.plot(time_range.datetime64[measurements_from_b],
                  DUT1_b[measurements_from_b], 'r--', lw=2, label='IERS Bulletin B')
     ax.set(xlabel='Year', ylabel='UT1-UTC [seconds]')
     ax.legend(loc='upper right')


### PR DESCRIPTION
This fixes two warnings I saw when running tests:

1. Deprecation warning for `ax.plot_date`: fixed by using `ax.plot` with `datetime64` instead
2. Warnings about non-rotation transforms when calculating Sun and Moon separations. Fixed by adding `origin_mismach="ignore"` to those two calculations. There is already a comment about this before both instances and removing the warning avoids end users seeing it and wondering if something is wrong with how they specified coordinates.