### PR TITLE
Fix `TimeDeltaMissingUnitWarning` in `plot_airmass`

### DIFF
--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -161,7 +161,7 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
         tzname = time.tzname()
         tzinfo = time.tzinfo
     else:
-        tzoffset = 0
+        tzoffset = 0 * u.hour
         tzname = 'UTC'
         tzinfo = None
     # Populate time window if needed.


### PR DESCRIPTION
The function `plot_airmass` triggers the warning `TimeDeltaMissingUnitWarning`. This issue arises from unit checks implemented in newer versions of Astropy (refer to commit d8968b29a209fdaebd0f48ff30863718bca9db78).

The warning is generated because a time value without a unit is being added to an Astropy Time object. To resolve this warning, it is recommended to add the unit `u.hour` to the time value.