### PR TITLE
Fix installation by pinning setuptools_scm to previous release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
 requires = ["setuptools",
-            "setuptools_scm"]
+            "setuptools_scm==8.3.1"]
 build-backend = 'setuptools.build_meta'

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ github_project = astropy/astroplan
 zip_safe = False
 packages = find:
 python_requires = >=3.7
-setup_requires = setuptools_scm
+setup_requires = setuptools_scm<9.0
 install_requires =
     numpy>=1.17
     astropy>=4


### PR DESCRIPTION
Unfortunately, due to the release of setuptools_scm 9.0.4 today, astroplan can no longer be installed.

This is because setuptools_scm now insists on there being a certain field in your pyproject.toml. I don't really understand why this is so, but since it worked two hours ago with version 8.3.1, this MR simply pins to that version of setuptools_scm.