### PR TITLE
Remove `grid` kwarg from `SkyView.get_images()` call

### DIFF
--- a/astroplan/plots/finder.py
+++ b/astroplan/plots/finder.py
@@ -84,7 +84,7 @@ def plot_finder_image(target, survey='DSS', fov_radius=10*u.arcmin,
     target_name = None if isinstance(target, SkyCoord) else target.name
 
     hdu = SkyView.get_images(position=position, coordinates=coordinates,
-                             survey=survey, radius=fov_radius, grid=grid)[0][0]
+                             survey=survey, radius=fov_radius)[0][0]
     wcs = WCS(hdu.header)
 
     # Set up axes & plot styles if needed.


### PR DESCRIPTION
As of astropy/astroquery#2979 (May 2024), `SkyView.get_images()` no longer accepts a `grid` keyword argument. This pull request removes it from `plot_finder_image()` to prevent breakage/maintain compatibility.

Close https://github.com/astropy/astroplan/pull/591

Fixes https://github.com/astropy/astroplan/issues/588