### PR TITLE
Update Python versions in CI testing

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -30,15 +30,15 @@ jobs:
             python: 3.x
             toxenv: codestyle
 
-          - name: Python 3.7 with minimal dependencies
+          - name: Python 3.12 with minimal dependencies
             os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-test
+            python: '3.12'
+            toxenv: py312-test
 
-          - name: OS X - Python 3.9 with minimal dependencies
+          - name: OS X - Python 3.12 with minimal dependencies
             os: macos-latest
-            python: 3.9
-            toxenv: py39-test
+            python: '3.12'
+            toxenv: py312-test
 
           - name: Windows - Python 3.11 with all optional dependencies
             os: windows-latest


### PR DESCRIPTION
CI was previously trying to run on Python 3.7 and 3.9, neither of which even exist in [tox.ini](../blob/main/tox.ini) anymore. 3.7 is [end-of-life](https://devguide.python.org/versions/) and 3.9 is about to be.