### PR TITLE
Replace deprecated plot_date with plot

### DIFF
--- a/astroplan/plots/tests/test_sky.py
+++ b/astroplan/plots/tests/test_sky.py
@@ -1,6 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 
+from astropy.coordinates import EarthLocation, SkyCoord
+from astropy import units as u
+from astropy.time import Time
+
 try:
     import matplotlib  # noqa
     HAS_MATPLOTLIB = True
@@ -43,3 +47,41 @@ def test_timezone():
     now_ET = pytz.timezone('US/Eastern').localize(datetime.datetime.now())
 
     plot_airmass(betelgeuse, observer, now_ET, use_local_tz=True)
+
+
+@pytest.mark.skipif('not HAS_MATPLOTLIB')
+def test_plot_altitude():
+    import matplotlib.pyplot as plt
+
+    from astroplan import Observer
+    from astroplan.target import FixedTarget
+    from astroplan.plots.time_dependent import plot_altitude
+
+    location = EarthLocation.from_geodetic(lon=0*u.deg, lat=51*u.deg, height=0*u.m)
+    observer = Observer(location=location)
+    target = FixedTarget(coord=SkyCoord(ra=10*u.deg, dec=45*u.deg), name='test')
+    time = Time('2024-01-01 00:00:00')
+
+    fig, ax = plt.subplots()
+    result = plot_altitude(target, observer, time, ax=ax)
+    assert result is ax
+    plt.close(fig)
+
+
+@pytest.mark.skipif('not HAS_MATPLOTLIB')
+def test_plot_parallactic():
+    import matplotlib.pyplot as plt
+
+    from astroplan import Observer
+    from astroplan.target import FixedTarget
+    from astroplan.plots.time_dependent import plot_parallactic
+
+    location = EarthLocation.from_geodetic(lon=0*u.deg, lat=51*u.deg, height=0*u.m)
+    observer = Observer(location=location)
+    target = FixedTarget(coord=SkyCoord(ra=10*u.deg, dec=45*u.deg), name='test')
+    time = Time('2024-01-01 00:00:00')
+
+    fig, ax = plt.subplots()
+    result = plot_parallactic(target, observer, time, ax=ax)
+    assert result is ax
+    plt.close(fig)

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -191,10 +191,11 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
             target_name = ''
 
         # Plot data (against timezone-offset time)
-        ax.plot_date(timetoplot.plot_date, masked_airmass, label=target_name, **style_kwargs)
+        ax.plot(timetoplot.plot_date, masked_airmass, label=target_name, **style_kwargs)
 
     # Format the time axis
     xlo, xhi = (timetoplot[0]), (timetoplot[-1])
+    ax.xaxis_date()
     ax.set_xlim([xlo.plot_date, xhi.plot_date])
     date_formatter = dates.DateFormatter('%H:%M')
     ax.xaxis.set_major_formatter(date_formatter)
@@ -397,9 +398,10 @@ def plot_altitude(targets, observer, time, ax=None, style_kwargs=None,
             target_name = ''
 
         # Plot data
-        ax.plot_date(time.plot_date, masked_altitude, label=target_name, **style_kwargs)
+        ax.plot(time.plot_date, masked_altitude, label=target_name, **style_kwargs)
 
     # Format the time axis
+    ax.xaxis_date()
     ax.set_xlim([time[0].plot_date, time[-1].plot_date])
     date_formatter = dates.DateFormatter('%H:%M')
     ax.xaxis.set_major_formatter(date_formatter)
@@ -619,9 +621,10 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None,
     style_kwargs.setdefault('label', target_name)
 
     # Plot data.
-    ax.plot_date(time.plot_date, p_angle, **style_kwargs)
+    ax.plot(time.plot_date, p_angle, **style_kwargs)
 
     # Format the time axis
+    ax.xaxis_date()
     date_formatter = dates.DateFormatter('%H:%M')
     ax.xaxis.set_major_formatter(date_formatter)
     plt.setp(ax.get_xticklabels(), rotation=30, ha='right')

--- a/astroplan/plots/time_dependent.py
+++ b/astroplan/plots/time_dependent.py
@@ -154,7 +154,7 @@ def plot_airmass(targets, observer, time, ax=None, style_kwargs=None,
     if 'lw' not in style_kwargs:
         style_kwargs.setdefault('linewidth', 1.5)
     if 'ls' not in style_kwargs and 'linestyle' not in style_kwargs:
-        style_kwargs.setdefault('fmt', '-')
+        style_kwargs.setdefault('linestyle', '-')
 
     if hasattr(time, 'utcoffset') and use_local_tz:
         tzoffset = time.utcoffset()
@@ -368,7 +368,7 @@ def plot_altitude(targets, observer, time, ax=None, style_kwargs=None,
     if style_kwargs is None:
         style_kwargs = {}
     style_kwargs = dict(style_kwargs)
-    if 'ls' not in style_kwargs and 'fmt' not in style_kwargs:
+    if 'ls' not in style_kwargs and 'linestyle' not in style_kwargs:
         style_kwargs.setdefault('linestyle', '-')
     if 'lw' not in style_kwargs:
         style_kwargs.setdefault('linewidth', 1.5)
@@ -595,8 +595,7 @@ def plot_parallactic(target, observer, time, ax=None, style_kwargs=None,
     if style_kwargs is None:
         style_kwargs = {}
     style_kwargs = dict(style_kwargs)
-    style_kwargs.setdefault('fmt', '-')
-    if 'ls' not in style_kwargs and 'fmt' not in style_kwargs:
+    if 'ls' not in style_kwargs and 'linestyle' not in style_kwargs:
         style_kwargs.setdefault('linestyle', '-')
 
     # Populate time window if needed.


### PR DESCRIPTION
Fixes #603.

`ax.plot_date()` was deprecated in matplotlib 3.9. Replaced with `ax.plot()` in `plot_airmass`, `plot_altitude`, and `plot_parallactic`. Added `ax.xaxis_date()` before each formatting block so the axis still uses date-aware locating.
